### PR TITLE
Make token expiry and scope optional in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.2] - 20260226
+
+### Changed
+
+- **Breaking**: Made `expires_in`, `refresh_token`, and `scope` optional in token response and session structs to comply with OAuth2/OIDC specifications
+  - `AccessTokenResponse`: `expires_in` is now `Option<i64>`, `refresh_token` is now `Option<String>`, `scope` is now `Option<String>`
+  - `RefreshTokenResponse`: `expires_in` is now `Option<i64>`
+  - `AuthSession`: `expires` is now `Option<DateTime<Local>>`, `refresh_token` is now `Option<String>`, `scope` is now `Option<String>`
+  - `calculate_token_expiration` now accepts `Option<i64>` for `expires_in` and returns `Option<DateTime<Local>>`; returns `None` when both `expires_in` and `token_max_age` are absent
+  - Token refresh logic is automatically disabled when `AuthSession.expires` is `None` (i.e. neither `expires_in` nor `token_max_age` were available at session creation)
+  - Token refresh logic is automatically skipped when `AuthSession.refresh_token` is `None`
+  - After a successful token refresh, `session.expires` is only updated if the refresh response provides new expiry information
+  - Updated sample protected route to gracefully display `"(no expiry)"` and `"(none)"` when optional fields are absent
+
+## [0.1.1] - 2026
 
 ### Added
 
@@ -72,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `examples/sample-server/src/config.rs`: Added clarifying comments for `end_session_endpoint`
   - `examples/sample-server/src/env.rs`: Updated environment variable documentation
 
-## [0.1.0] - 2024
+## [0.1.0] - 2026
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"

--- a/examples/sample-server/src/routes/protected.rs
+++ b/examples/sample-server/src/routes/protected.rs
@@ -51,8 +51,11 @@ use chrono::Local;
 pub async fn protected(session: AuthSession) -> Html<String> {
     let token_type = &session.token_type;
     let now = Local::now();
-    let expires = session.expires;
-    let scope = &session.scope;
+    let expires = session
+        .expires
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| "(no expiry)".to_string());
+    let scope = session.scope.as_deref().unwrap_or("(none)");
     let access_token_session = &session.access_token;
     let id_token = &session.id_token;
 

--- a/src/auth_router/handle_callback.rs
+++ b/src/auth_router/handle_callback.rs
@@ -26,9 +26,12 @@ pub struct AccessTokenResponse {
     pub id_token: String,
     pub access_token: String,
     pub token_type: String,
-    pub expires_in: i64,
-    pub refresh_token: String,
-    pub scope: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expires_in: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub refresh_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scope: Option<String>,
 }
 
 async fn get_auth_tokens(


### PR DESCRIPTION
- Treat expires, refresh_token, and scope as optional across the authentication flow
- Refactor calculate_token_expiration to return Option<DateTime<Local>>
- Update AuthSession: expires becomes Option<DateTime<Local>>, scope and refresh_token become Option
- Update token response structs to use Option fields with skip_serializing_if
- Update refresh logic to handle missing expiry and skip refresh when no expiry is present
- Update sample protected route to display "(no expiry)" and "(none)"

## Summary by Sourcery

Make token expiry, refresh token, and scope optional throughout the authentication flow and adjust session handling and examples accordingly.

Bug Fixes:
- Avoid refresh attempts when no refresh token is present, treating such sessions as expired instead.
- Preserve existing session expiry when a refresh response omits new expiration information.

Enhancements:
- Allow token responses and sessions to omit expiry, refresh token, and scope fields, aligning with OAuth2/OIDC flexibility.
- Change token expiration calculation to work with optional expiry inputs and to disable refresh logic when no expiry is tracked.
- Adjust automatic session refresh logic and sample routes to gracefully handle missing expiry and scope metadata.

Build:
- Bump crate version to 0.1.2.

Documentation:
- Update changelog and inline documentation to describe the new optional token/session fields and refresh behavior.