### PR TITLE
Add two-tier cache with Moka L1 and optional L2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 20260226
+## [0.2.0] - 2026-03-04
+
+### Added
+
+- **Feature**: Two-tier authentication cache (`cache` module, requires `moka-cache` feature)
+  - Introduced `TwoTierAuthCache`: combines a fast in-process [Moka](https://crates.io/crates/moka) L1 cache with any `AuthCache` implementation as the L2 backend (e.g. Redis)
+  - Implements a cache-aside pattern: reads check L1 first; on miss, L2 is queried and the result is promoted to L1; writes and invalidations are applied to both tiers
+  - `TwoTierCacheConfig` struct to tune L1 behaviour:
+    - `l1_max_capacity`: maximum number of entries (default `10_000`)
+    - `l1_ttl_sec`: time-to-live per entry in seconds (default `3600`)
+    - `l1_time_to_idle_sec`: optional idle-eviction timeout (default `None`)
+    - `enable_l1`: bypass Moka entirely when set to `false` (useful for testing)
+  - L2 backend is optional: the cache can operate in L1-only mode (no L2) or L2-only mode (L1 disabled)
+  - Comprehensive unit-test suite covering all combinations of L1-only, L2-only and two-tier modes
+  - Public API exposed via `axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig}`
+
+### Changed
+
+- **Cargo features**: renamed the `moka` feature to `moka-cache` to better reflect its purpose and avoid a name collision with the `moka` dependency; `moka-cache` is now a **default feature**
+- **Dependency**: enabled the `future` feature of the `moka` crate to support async cache operations
+- **Documentation** (`src/lib.rs`): documented the new `cache` module and `moka-cache` feature in the crate-level rustdoc
+
+## [0.1.2] - 2026-02-26
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"
@@ -30,12 +30,12 @@ urlencoding = "2.1"
 uuid = { version = "1.18.1", features = ["v4"] }
 time = "0.3.44"
 redis = { version = "1.0.0-rc.3", optional = true, features = ["tokio-comp", "connection-manager"]}
-moka = { version = "0.12.11", optional = true}
+moka = { version = "0.12.11", optional = true, features = ["future"]}
 chrono = {version = "0.4.42", features = ["serde"]}
 
 [features]
-# Defines a feature named `webp` that does not enable any other features.
-moka = ["dep:moka"]
+default = ["moka-cache"]
+moka-cache = ["dep:moka"]
 redis = ["dep:redis"]
 redis-native-tls= ["redis", "redis?/tokio-native-tls-comp"] #"tokio-native-tls-comp"
 redis-rustls = ["redis", "redis?/tokio-rustls-comp"] #"tokio-rustls-comp"

--- a/examples/sample-server/Cargo.toml
+++ b/examples/sample-server/Cargo.toml
@@ -3,6 +3,33 @@ name = "axum-sample-server"
 version = "0.1.0"
 edition = "2021"
 
+# ─── Cache feature flags ──────────────────────────────────────────────────────
+#
+# Exactly one of the three cache features should be enabled at a time.
+# Enabling multiple explicit features (e.g. cache-l1 + cache-l2) is equivalent
+# to enabling cache-l1-l2 and will compile the two-tier implementation.
+#
+#   cargo run                                  # default: cache-l1 (Moka in-process only)
+#   cargo run --no-default-features \
+#             --features cache-l1             # Moka in-process only
+#   cargo run --no-default-features \
+#             --features cache-l2             # Redis only
+#   cargo run --no-default-features \
+#             --features cache-l1-l2          # Moka L1 + Redis L2
+#
+[features]
+## L2-only: Redis-backed session cache with no in-process layer.
+cache-l2 = ["axum-oidc-client/redis-rustls"]
+
+## L1-only: Moka in-process cache.  No external backend required.
+cache-l1 = ["axum-oidc-client/moka-cache"]
+
+## Two-tier: Moka L1 in front of Redis L2.
+cache-l1-l2 = ["cache-l1", "cache-l2"]
+
+## Default: Moka in-process cache — no external backend required.
+default = ["cache-l1"]
+
 [dependencies]
 axum = "0.8.4"
 axum-extra = { version = "0.10.0", features = [
@@ -18,7 +45,9 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }
-axum-oidc-client = { path = "../.." , features=["redis-rustls"]}
+# Cache features are activated transitively through this crate's own features
+# (see the [features] section above); do NOT hard-code them here.
+axum-oidc-client = { path = "../.." }
 clap = { version = "4.5.51", features = ["derive", "env"] }
 clap_derive = "4.5.49"
 dotenv = "0.15"

--- a/examples/sample-server/Makefile
+++ b/examples/sample-server/Makefile
@@ -11,6 +11,23 @@ WATCH_DELAY = 1
 PORT ?= 8080
 HOST ?= 127.0.0.1
 
+# ── Cache feature selection ────────────────────────────────────────────────────
+# Select the cache backend at compile time via FEATURES.
+# Possible values:
+#   cache-l1      Moka in-process only (default, no Redis required)
+#   cache-l2      Redis only
+#   cache-l1-l2   Two-tier: Moka L1 in front of Redis L2
+#
+# Override on the command line:
+#   make run FEATURES=cache-l2
+#   make dev FEATURES=cache-l1-l2
+#
+FEATURES ?= cache-l1
+# Translate FEATURES into the cargo flag pair used by all targets below.
+CARGO_FEATURES = --no-default-features --features $(FEATURES)
+
+# ──────────────────────────────────────────────────────────────────────────────
+
 # Color output
 RED = \033[0;31m
 GREEN = \033[0;32m
@@ -24,38 +41,55 @@ help:
 	@echo -e "$(GREEN)Sample Server Development Commands$(NC)"
 	@echo ""
 	@echo -e "$(YELLOW)Setup:$(NC)"
-	@echo "  make install       - Install cargo-watch and dependencies"
-	@echo "  make setup         - Create .env.local from sample if it doesn't exist"
+	@echo "  make install         - Install cargo-watch and dependencies"
+	@echo "  make setup           - Create .env.local from sample if it doesn't exist"
 	@echo ""
-	@echo -e "$(YELLOW)Development:$(NC)"
-	@echo "  make dev           - Run with cargo-watch (auto-reload on changes)"
-	@echo "  make run           - Run without watching"
-	@echo "  make watch         - Alias for 'make dev'"
+	@echo -e "$(YELLOW)Development (generic – honours FEATURES variable):$(NC)"
+	@echo "  make dev             - Run with cargo-watch (auto-reload on changes)"
+	@echo "  make run             - Run without watching"
+	@echo "  make watch           - Alias for 'make dev'"
+	@echo ""
+	@echo -e "$(YELLOW)Cache-specific shortcuts:$(NC)"
+	@echo "  make run-l2          - Run with Redis-only cache        (cache-l2)"
+	@echo "  make run-l1          - Run with Moka in-process cache   (cache-l1, no Redis needed)"
+	@echo "  make run-l1-l2       - Run with two-tier cache          (cache-l1-l2)"
+	@echo "  make dev-l2          - Watch-run with Redis-only cache"
+	@echo "  make dev-l1          - Watch-run with Moka in-process cache"
+	@echo "  make dev-l1-l2       - Watch-run with two-tier cache"
+	@echo "  make build-l2        - Build with Redis-only cache"
+	@echo "  make build-l1        - Build with Moka in-process cache"
+	@echo "  make build-l1-l2     - Build with two-tier cache"
 	@echo ""
 	@echo -e "$(YELLOW)Build:$(NC)"
-	@echo "  make build         - Build in debug mode"
-	@echo "  make release       - Build in release mode"
-	@echo "  make clean         - Clean build artifacts"
+	@echo "  make build           - Build in debug mode (uses FEATURES=$(FEATURES))"
+	@echo "  make release         - Build in release mode"
+	@echo "  make clean           - Clean build artifacts"
 	@echo ""
 	@echo -e "$(YELLOW)Testing:$(NC)"
-	@echo "  make test          - Run tests"
-	@echo "  make test-watch    - Run tests with auto-reload"
+	@echo "  make test            - Run tests"
+	@echo "  make test-watch      - Run tests with auto-reload"
 	@echo ""
 	@echo -e "$(YELLOW)Utilities:$(NC)"
-	@echo "  make check         - Check code (cargo check)"
-	@echo "  make fmt           - Format code"
-	@echo "  make clippy        - Run clippy linter"
-	@echo "  make env           - Show current environment variables"
+	@echo "  make check           - Check code (cargo check)"
+	@echo "  make fmt             - Format code"
+	@echo "  make clippy          - Run clippy linter"
+	@echo "  make env             - Show current environment variables"
 	@echo ""
-	@echo -e "$(YELLOW)Environment:$(NC)"
-	@echo "  PORT=$(PORT) (override with PORT=3000 make dev)"
+	@echo -e "$(YELLOW)Environment / overrides:$(NC)"
+	@echo "  PORT=$(PORT)    (override with PORT=3000 make dev)"
 	@echo "  HOST=$(HOST) (override with HOST=0.0.0.0 make dev)"
-	@echo "  ENV_FILE=$(ENV_FILE) (override with DOTENV_FILE=.env.prod make dev)"
+	@echo "  FEATURES=$(FEATURES)  (override with FEATURES=cache-l2 make run)"
+	@echo "  ENV_FILE=$(ENV_FILE)  (override with DOTENV_FILE=.env.prod make dev)"
 	@echo ""
 	@echo -e "$(BLUE)Priority for .env files:$(NC)"
 	@echo "  1. DOTENV_FILE environment variable (if set)"
 	@echo "  2. .env.local (default)"
 	@echo "  3. .env (fallback)"
+	@echo ""
+	@echo -e "$(BLUE)Cache feature summary:$(NC)"
+	@echo "  cache-l1      Moka in-process only  (default, no external backend)"
+	@echo "  cache-l2      Redis only            (requires Redis)"
+	@echo "  cache-l1-l2   Moka L1 + Redis L2    (two-tier, requires Redis)"
 
 # Install cargo-watch if not already installed
 .PHONY: install
@@ -109,6 +143,7 @@ setup:
 dev: install setup
 	@echo -e "$(GREEN)Starting development server with hot-reloading...$(NC)"
 	@echo -e "$(BLUE)Configuration:$(NC)"
+	@echo "  • Cache feature:  $(FEATURES)"
 	@echo "  • Watching for file changes"
 	@echo "  • Debounce delay: $(WATCH_DELAY) second"
 	@echo "  • Environment file: $(ENV_FILE)"
@@ -131,11 +166,24 @@ dev: install setup
 			--ignore "*.log" \
 			--ignore "target/*" \
 			--why \
-			-x "run -- --host $(HOST) --port $(PORT)"; \
+			-x "run $(CARGO_FEATURES) -- --host $(HOST) --port $(PORT)"; \
 	else \
 		echo -e "$(RED)Error: $(ENV_FILE) not found. Run 'make setup' first.$(NC)"; \
 		exit 1; \
 	fi
+
+# ── Cache-specific dev targets ─────────────────────────────────────────────────
+.PHONY: dev-l2
+dev-l2:
+	@$(MAKE) dev FEATURES=cache-l2
+
+.PHONY: dev-l1
+dev-l1:
+	@$(MAKE) dev FEATURES=cache-l1
+
+.PHONY: dev-l1-l2
+dev-l1-l2:
+	@$(MAKE) dev FEATURES=cache-l1-l2
 
 # Alias for dev
 .PHONY: watch
@@ -144,28 +192,54 @@ watch: dev
 # Run without watching
 .PHONY: run
 run: setup
-	@echo -e "$(GREEN)Starting server...$(NC)"
+	@echo -e "$(GREEN)Starting server (cache: $(FEATURES))...$(NC)"
 	@if [ -n "$(DOTENV_FILE)" ]; then \
 		echo -e "$(BLUE)Using custom dotenv file: $(DOTENV_FILE)$(NC)"; \
 	fi
 	@if [ -f $(ENV_FILE) ]; then \
-		DOTENV_FILE=$(ENV_FILE) $(CARGO) run -- --host $(HOST) --port $(PORT); \
+		DOTENV_FILE=$(ENV_FILE) $(CARGO) run $(CARGO_FEATURES) -- --host $(HOST) --port $(PORT); \
 	else \
 		echo -e "$(RED)Error: $(ENV_FILE) not found. Run 'make setup' first.$(NC)"; \
 		exit 1; \
 	fi
 
+# ── Cache-specific run targets ─────────────────────────────────────────────────
+.PHONY: run-l2
+run-l2:
+	@$(MAKE) run FEATURES=cache-l2
+
+.PHONY: run-l1
+run-l1:
+	@$(MAKE) run FEATURES=cache-l1
+
+.PHONY: run-l1-l2
+run-l1-l2:
+	@$(MAKE) run FEATURES=cache-l1-l2
+
 # Build commands
 .PHONY: build
 build:
-	@echo -e "$(BLUE)Building in debug mode...$(NC)"
-	@$(CARGO) build
+	@echo -e "$(BLUE)Building in debug mode (cache: $(FEATURES))...$(NC)"
+	@$(CARGO) build $(CARGO_FEATURES)
 	@echo -e "$(GREEN)✓ Build complete$(NC)"
+
+# ── Cache-specific build targets ───────────────────────────────────────────────
+.PHONY: build-l2
+build-l2:
+	@$(MAKE) build FEATURES=cache-l2
+
+.PHONY: build-l1
+build-l1:
+	@$(MAKE) build FEATURES=cache-l1
+
+.PHONY: build-l1-l2
+build-l1-l2:
+	@$(MAKE) build FEATURES=cache-l1-l2
 
 .PHONY: release
 release:
-	@echo -e "$(BLUE)Building in release mode...$(NC)"
-	@$(CARGO) build --release
+	@echo -e "$(BLUE)Building in release mode (cache: $(FEATURES))...$(NC)"
+	@$(CARGO) build --release $(CARGO_FEATURES)
 	@echo -e "$(GREEN)✓ Release build complete$(NC)"
 
 .PHONY: clean
@@ -194,8 +268,8 @@ test-watch: install
 # Code quality
 .PHONY: check
 check:
-	@echo -e "$(BLUE)Running cargo check...$(NC)"
-	@$(CARGO) check
+	@echo -e "$(BLUE)Running cargo check (cache: $(FEATURES))...$(NC)"
+	@$(CARGO) check $(CARGO_FEATURES)
 	@echo -e "$(GREEN)✓ Check complete$(NC)"
 
 .PHONY: fmt
@@ -206,8 +280,8 @@ fmt:
 
 .PHONY: clippy
 clippy:
-	@echo -e "$(BLUE)Running clippy...$(NC)"
-	@$(CARGO) clippy -- -D warnings
+	@echo -e "$(BLUE)Running clippy (cache: $(FEATURES))...$(NC)"
+	@$(CARGO) clippy $(CARGO_FEATURES) -- -D warnings
 	@echo -e "$(GREEN)✓ Clippy complete$(NC)"
 
 # Show environment variables

--- a/examples/sample-server/README.md
+++ b/examples/sample-server/README.md
@@ -30,10 +30,33 @@ cp .env.azure.example .env
 
 Edit `.env` with your actual credentials.
 
-### 3. Run the Server
+### 3. Choose a Cache Backend
+
+The cache backend is selected at **compile time** via a Cargo feature flag.
+Three modes are available:
+
+| Feature       | Cache type                    | External dependency |
+| ------------- | ----------------------------- | ------------------- |
+| `cache-l2`    | Redis only                    | Redis server        |
+| `cache-l1`    | Moka in-process only *(default)* | None             |
+| `cache-l1-l2` | Moka L1 + Redis L2 (two-tier) | Redis server        |
+
+See [Cache Backends](#cache-backends) for full details.
+
+### 4. Run the Server
 
 ```bash
+# Default: Moka in-process cache (no Redis needed)
 cargo run
+
+# Explicit Moka in-process cache
+cargo run --no-default-features --features cache-l1
+
+# Redis only
+cargo run --no-default-features --features cache-l2
+
+# Two-tier: Moka L1 + Redis L2
+cargo run --no-default-features --features cache-l1-l2
 ```
 
 Or use environment variables directly:
@@ -42,7 +65,7 @@ Or use environment variables directly:
 OAUTH_CLIENT_ID=your-id OAUTH_CLIENT_SECRET=your-secret cargo run
 ```
 
-### 4. Test the Flow
+### 5. Test the Flow
 
 1. Visit http://localhost:8080
 2. Click "Login" to start OAuth flow
@@ -50,21 +73,118 @@ OAUTH_CLIENT_ID=your-id OAUTH_CLIENT_SECRET=your-secret cargo run
 4. Access protected routes
 5. Click "Logout" to end session
 
+---
+
+## Cache Backends
+
+The cache backend is chosen at **compile time** by passing a `--features` flag to
+Cargo.  Only one combination should be active at a time; enabling both `cache-l1`
+and `cache-l2` individually is identical to enabling `cache-l1-l2`.
+
+> **Compile-time guard:** Building with `--no-default-features` and no cache
+> feature produces a clear compile error listing the available options.
+
+### `cache-l2` — Redis only
+
+Stores all session data in Redis.
+
+```bash
+cargo run --no-default-features --features cache-l2
+```
+
+**Additional CLI args / env vars:**
+
+| CLI argument  | Environment variable | Default                | Description                        |
+| ------------- | -------------------- | ---------------------- | ---------------------------------- |
+| `--redis-url` | `REDIS_URL`          | `redis://127.0.0.1/`   | Redis connection URL               |
+| `--cache-ttl` | `CACHE_TTL`          | `3600`                 | Session TTL in seconds             |
+
+**`.env` snippet:**
+
+```env
+REDIS_URL=redis://127.0.0.1/
+CACHE_TTL=3600
+```
+
+### `cache-l1` — Moka in-process only (default)
+
+Stores all session data in a fast, bounded in-process cache using
+[Moka](https://crates.io/crates/moka).  No external backend required — ideal
+for local development or single-instance deployments where Redis is not
+available.  This is the **default** when no feature flag is specified.
+
+> **Note:** `extend_auth_session` resets the entry's wall-clock TTL to
+> `L1_TTL_SEC` (re-insertion) rather than extending by an arbitrary delta,
+> because Moka does not support per-entry TTL updates.
+
+```bash
+cargo run                                          # uses default = ["cache-l1"]
+cargo run --no-default-features --features cache-l1
+```
+
+**Additional CLI args / env vars:**
+
+| CLI argument           | Environment variable   | Default  | Description                                              |
+| ---------------------- | ---------------------- | -------- | -------------------------------------------------------- |
+| `--l1-max-capacity`    | `L1_MAX_CAPACITY`      | `10000`  | Maximum number of entries held by Moka                   |
+| `--l1-ttl-sec`         | `L1_TTL_SEC`           | `3600`   | Time-to-live for L1 entries (seconds)                    |
+| `--l1-time-to-idle-sec`| `L1_TIME_TO_IDLE_SEC`  | *(unset)*| Idle-eviction timeout in seconds; omit to disable        |
+
+**`.env` snippet:**
+
+```env
+L1_MAX_CAPACITY=10000
+L1_TTL_SEC=3600
+# L1_TIME_TO_IDLE_SEC=1800   # optional: evict idle entries after 30 min
+```
+
+### `cache-l1-l2` — Two-tier: Moka L1 + Redis L2
+
+Combines both tiers using a **cache-aside** pattern:
+
+| Operation      | L1 (Moka)                              | L2 (Redis)                     |
+| -------------- | -------------------------------------- | ------------------------------ |
+| **Read**       | Check first; on miss go to L2          | Read on L1 miss; populate L1   |
+| **Write**      | Write                                  | Write first (source of truth)  |
+| **Invalidate** | Remove                                 | Remove                         |
+| **Extend TTL** | Evict (re-fetched on next read)        | Extend                         |
+
+```bash
+cargo run --no-default-features --features cache-l1-l2
+```
+
+**Additional CLI args / env vars:** all of `cache-l1` and `cache-l2` combined.
+
+**`.env` snippet:**
+
+```env
+# Redis (L2)
+REDIS_URL=redis://127.0.0.1/
+CACHE_TTL=3600
+
+# Moka (L1) – TTL should match or slightly exceed CACHE_TTL
+L1_MAX_CAPACITY=10000
+L1_TTL_SEC=3600
+# L1_TIME_TO_IDLE_SEC=1800
+```
+
+---
+
 ## Provider Configuration
 
 Provider-specific example files are available:
 
-- `.env.google.example` - Google OAuth2 configuration
-- `.env.github.example` - GitHub OAuth2 configuration
-- `.env.keycloak.example` - Keycloak OIDC configuration
-- `.env.azure.example` - Azure AD / Microsoft Identity Platform
+- `.env.google.example` — Google OAuth2 configuration
+- `.env.github.example` — GitHub OAuth2 configuration
+- `.env.keycloak.example` — Keycloak OIDC configuration
+- `.env.azure.example` — Azure AD / Microsoft Identity Platform
 
 ### Google
 
-**Note:** Google does NOT support OIDC logout. Use default configuration without `end_session_endpoint`.
+> **Note:** Google does NOT support OIDC logout. Do **not** set
+> `OAUTH_END_SESSION_ENDPOINT`.
 
-```bash
-# .env
+```env
 OAUTH_AUTHORIZATION_ENDPOINT=https://accounts.google.com/o/oauth2/auth
 OAUTH_TOKEN_ENDPOINT=https://oauth2.googleapis.com/token
 OAUTH_CLIENT_ID=your-id.apps.googleusercontent.com
@@ -72,7 +192,6 @@ OAUTH_CLIENT_SECRET=your-secret
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback
 OAUTH_SCOPES=openid,email,profile
 PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
-# Do NOT set OAUTH_END_SESSION_ENDPOINT for Google
 ```
 
 **Setup:**
@@ -84,10 +203,9 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 
 ### GitHub
 
-**Note:** GitHub does NOT support OIDC logout. Use default configuration.
+> **Note:** GitHub does NOT support OIDC logout. Use default configuration.
 
-```bash
-# .env
+```env
 OAUTH_AUTHORIZATION_ENDPOINT=https://github.com/login/oauth/authorize
 OAUTH_TOKEN_ENDPOINT=https://github.com/login/oauth/access_token
 OAUTH_CLIENT_ID=your-github-client-id
@@ -95,7 +213,6 @@ OAUTH_CLIENT_SECRET=your-github-secret
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback
 OAUTH_SCOPES=read:user,user:email
 PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
-# Do NOT set OAUTH_END_SESSION_ENDPOINT for GitHub
 ```
 
 **Setup:**
@@ -106,10 +223,9 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 
 ### Keycloak
 
-**Note:** Keycloak supports full OIDC including logout. Set `end_session_endpoint`.
+> **Note:** Keycloak supports full OIDC including logout. Set `OAUTH_END_SESSION_ENDPOINT`.
 
-```bash
-# .env
+```env
 KEYCLOAK_URL=https://keycloak.example.com
 KEYCLOAK_REALM=your-realm
 
@@ -135,10 +251,9 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 
 ### Azure AD
 
-**Note:** Azure AD supports full OIDC including logout.
+> **Note:** Azure AD supports full OIDC including logout.
 
-```bash
-# .env
+```env
 AZURE_TENANT=common  # or your tenant ID
 
 OAUTH_AUTHORIZATION_ENDPOINT=https://login.microsoftonline.com/${AZURE_TENANT}/oauth2/v2.0/authorize
@@ -162,10 +277,9 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 
 ### Okta
 
-**Note:** Okta supports full OIDC including logout.
+> **Note:** Okta supports full OIDC including logout.
 
-```bash
-# .env
+```env
 OKTA_DOMAIN=your-domain.okta.com
 
 OAUTH_AUTHORIZATION_ENDPOINT=https://${OKTA_DOMAIN}/oauth2/default/v1/authorize
@@ -188,10 +302,9 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 
 ### Auth0
 
-**Note:** Auth0 supports full OIDC including logout.
+> **Note:** Auth0 supports full OIDC including logout.
 
-```bash
-# .env
+```env
 AUTH0_DOMAIN=your-tenant.auth0.com
 
 OAUTH_AUTHORIZATION_ENDPOINT=https://${AUTH0_DOMAIN}/authorize
@@ -212,17 +325,47 @@ PRIVATE_COOKIE_KEY=generate-with-openssl-rand-base64-64
 3. Add Allowed Callback URLs: `http://localhost:8080/auth/callback`
 4. Add Allowed Logout URLs: `http://localhost:8080`
 
+---
+
 ## Command Line Usage
 
 ### Basic Usage
 
 ```bash
-# With command-line arguments
+# With command-line arguments (default: Moka in-process cache)
 cargo run -- \
   --client-id YOUR_ID \
   --client-secret YOUR_SECRET \
   --authorization-endpoint https://provider.com/authorize \
   --token-endpoint https://provider.com/token
+```
+
+### Selecting a Cache Backend
+
+```bash
+# Moka in-process only (default — no Redis needed)
+cargo run -- --client-id YOUR_ID --client-secret YOUR_SECRET
+
+# Explicit Moka in-process only
+cargo run --no-default-features --features cache-l1 -- \
+  --client-id YOUR_ID --client-secret YOUR_SECRET \
+  --l1-max-capacity 5000 \
+  --l1-ttl-sec 1800
+
+# Redis only
+cargo run --no-default-features --features cache-l2 -- \
+  --client-id YOUR_ID --client-secret YOUR_SECRET \
+  --redis-url redis://127.0.0.1/ \
+  --cache-ttl 3600
+
+# Two-tier (Moka L1 + Redis L2)
+cargo run --no-default-features --features cache-l1-l2 -- \
+  --client-id YOUR_ID --client-secret YOUR_SECRET \
+  --redis-url redis://127.0.0.1/ \
+  --cache-ttl 3600 \
+  --l1-max-capacity 10000 \
+  --l1-ttl-sec 3600 \
+  --l1-time-to-idle-sec 1800
 ```
 
 ### With OIDC Logout (Keycloak, Azure AD, Okta, Auth0)
@@ -240,27 +383,107 @@ cargo run -- \
 ### View All Options
 
 ```bash
+# Options vary depending on the active cache feature
 cargo run -- --help
+cargo run --no-default-features --features cache-l1 -- --help
+cargo run --no-default-features --features cache-l1-l2 -- --help
 ```
+
+---
+
+## Make Targets
+
+The `Makefile` wraps common Cargo commands and supports a `FEATURES` variable
+(default: `cache-l1`) that is forwarded to every `cargo` invocation.
+
+### Generic targets (honour `FEATURES`)
+
+```bash
+make run                    # run with FEATURES=cache-l1 (default)
+make run FEATURES=cache-l1  # override at call site
+make dev FEATURES=cache-l1-l2
+make build FEATURES=cache-l1
+```
+
+### Cache-specific shortcuts
+
+```bash
+# Run
+make run-l2        # Redis only
+make run-l1        # Moka in-process only
+make run-l1-l2     # Two-tier
+
+# Watch-run (requires cargo-watch)
+make dev-l2
+make dev-l1
+make dev-l1-l2
+
+# Build only
+make build-l2
+make build-l1
+make build-l1-l2
+```
+
+### Other useful targets
+
+```bash
+make install       # install cargo-watch
+make setup         # create .env.local from sample
+make test          # run tests
+make check         # cargo check
+make fmt           # cargo fmt
+make clippy        # cargo clippy
+make clean         # clean build artifacts
+make env           # print current .env.local contents
+make help          # show all targets with descriptions
+```
+
+### Environment overrides
+
+```bash
+make run PORT=3000 HOST=0.0.0.0 FEATURES=cache-l1
+DOTENV_FILE=.env.prod make run-l1-l2
+```
+
+---
 
 ## Environment Variables
 
+### OAuth2 / OIDC
+
 All CLI arguments can be set via environment variables:
 
-| CLI Argument                 | Environment Variable           | Required | Default                                      |
+| CLI argument                 | Environment variable           | Required | Default                                      |
 | ---------------------------- | ------------------------------ | -------- | -------------------------------------------- |
-| `--client-id`                | `OAUTH_CLIENT_ID`              | Yes      | -                                            |
-| `--client-secret`            | `OAUTH_CLIENT_SECRET`          | Yes      | -                                            |
+| `--client-id`                | `OAUTH_CLIENT_ID`              | Yes      | —                                            |
+| `--client-secret`            | `OAUTH_CLIENT_SECRET`          | Yes      | —                                            |
 | `--authorization-endpoint`   | `OAUTH_AUTHORIZATION_ENDPOINT` | No       | `https://accounts.google.com/o/oauth2/auth`  |
 | `--token-endpoint`           | `OAUTH_TOKEN_ENDPOINT`         | No       | `https://oauth2.googleapis.com/token`        |
-| `--end-session-endpoint`     | `OAUTH_END_SESSION_ENDPOINT`   | No       | None (only set for OIDC providers)           |
+| `--end-session-endpoint`     | `OAUTH_END_SESSION_ENDPOINT`   | No       | None (only for OIDC-compliant providers)     |
 | `--post-logout-redirect-uri` | `POST_LOGOUT_REDIRECT_URI`     | No       | `/`                                          |
 | `--redirect-uri`             | `OAUTH_REDIRECT_URI`           | No       | `http://localhost:8080/auth/callback`        |
 | `--base-path`                | `OAUTH_BASE_PATH`              | No       | `/auth`                                      |
-| `--private-cookie-key`       | `PRIVATE_COOKIE_KEY`           | No       | `private_cookie_key` (change in production!) |
+| `--private-cookie-key`       | `PRIVATE_COOKIE_KEY`           | No       | `private_cookie_key` *(change in prod!)*     |
 | `--scopes`                   | `OAUTH_SCOPES`                 | No       | `openid,email,profile`                       |
 | `--host`                     | `SERVER_HOST`                  | No       | `127.0.0.1`                                  |
 | `--port`                     | `SERVER_PORT`                  | No       | `8080`                                       |
+
+### Cache — L2 / Redis (`cache-l2`, `cache-l1-l2`)
+
+| CLI argument  | Environment variable | Default              | Description            |
+| ------------- | -------------------- | -------------------- | ---------------------- |
+| `--redis-url` | `REDIS_URL`          | `redis://127.0.0.1/` | Redis connection URL   |
+| `--cache-ttl` | `CACHE_TTL`          | `3600`               | Entry TTL in seconds   |
+
+### Cache — L1 / Moka (`cache-l1`, `cache-l1-l2`)
+
+| CLI argument            | Environment variable  | Default   | Description                              |
+| ----------------------- | --------------------- | --------- | ---------------------------------------- |
+| `--l1-max-capacity`     | `L1_MAX_CAPACITY`     | `10000`   | Maximum entries held by Moka             |
+| `--l1-ttl-sec`          | `L1_TTL_SEC`          | `3600`    | Entry TTL in seconds                     |
+| `--l1-time-to-idle-sec` | `L1_TIME_TO_IDLE_SEC` | *(unset)* | Idle-eviction timeout; omit to disable   |
+
+---
 
 ## Dotenv File Priority
 
@@ -272,53 +495,60 @@ The application loads environment variables from dotenv files in this order:
 
 Only the first existing file is loaded.
 
+---
+
 ## Generating Secure Keys
 
-Generate a secure private cookie key:
-
 ```bash
-# Generate a secure random key
+# Generate a secure random private cookie key
 openssl rand -base64 64
 
-# Use in .env file
+# Append it to your .env file
 echo "PRIVATE_COOKIE_KEY=$(openssl rand -base64 64)" >> .env
 ```
 
+---
+
 ## Available Routes
 
-| Route                             | Description                       | Auth Required |
+| Route                             | Description                       | Auth required |
 | --------------------------------- | --------------------------------- | ------------- |
-| `GET /`                           | Home page with login/logout links | No            |
-| `GET /public`                     | Public page                       | No            |
+| `GET /`                           | Home page (public)                | No            |
+| `GET /home`                       | Home page alias (public)          | No            |
 | `GET /protected`                  | Protected page                    | Yes           |
-| `GET /debug`                      | Session debug info                | Yes           |
 | `GET /auth`                       | Start OAuth flow (auto-redirect)  | No            |
 | `GET /auth/callback`              | OAuth callback (auto-handled)     | No            |
-| `GET /auth/logout`                | Logout and redirect to home       | No            |
-| `GET /auth/logout?redirect=/path` | Logout with custom redirect       | No            |
+| `GET /auth/logout`                | Logout → home                     | No            |
+| `GET /auth/logout?redirect=/path` | Logout → custom path              | No            |
+
+---
 
 ## Testing
 
 ### Manual Testing
 
-1. **Start server:** `cargo run`
+1. **Start server:** `cargo run` (or choose a cache feature)
 2. **Visit home:** http://localhost:8080
-3. **Click login:** Redirects to OAuth provider
-4. **Authenticate:** Login at provider
-5. **Redirected back:** Should see protected content
+3. **Click login:** Redirected to OAuth provider
+4. **Authenticate:** Log in at the provider
+5. **Redirected back:** See protected content
 6. **Visit protected route:** http://localhost:8080/protected
 7. **Click logout:** Session cleared, redirected home
 
-### Debug Session
+### Cache-specific Smoke Tests
 
-Visit http://localhost:8080/debug to see:
+```bash
+# Verify L1-only mode starts without Redis
+cargo run --no-default-features --features cache-l1 -- \
+  --client-id test --client-secret test
 
-- Token type
-- Expiration time
-- Current time
-- Whether token is expired
-- Scopes granted
-- Whether refresh token exists
+# Verify two-tier mode connects to Redis
+cargo run --no-default-features --features cache-l1-l2 -- \
+  --client-id test --client-secret test \
+  --redis-url redis://127.0.0.1/
+```
+
+---
 
 ## Troubleshooting
 
@@ -328,7 +558,8 @@ Ensure `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` are set.
 
 ### Redirect Loop
 
-Verify `OAUTH_REDIRECT_URI` matches exactly what's configured in your OAuth provider.
+Verify `OAUTH_REDIRECT_URI` matches exactly what is configured in your OAuth
+provider.
 
 ### "Invalid client" Error
 
@@ -338,46 +569,89 @@ Verify `OAUTH_REDIRECT_URI` matches exactly what's configured in your OAuth prov
 
 ### Session Not Persisting
 
-- Check Redis is running if using Redis cache
-- Verify cookies are enabled in browser
-- Check `PRIVATE_COOKIE_KEY` is set and consistent
+- If using `cache-l2` or `cache-l1-l2`: confirm Redis is running and
+  `REDIS_URL` is correct
+- If using `cache-l1`: sessions are in-process only and lost on restart
+- Verify cookies are enabled in the browser
+- Check `PRIVATE_COOKIE_KEY` is set and consistent across restarts
+
+### "At least one cache feature must be enabled" compile error
+
+You ran `cargo build --no-default-features` without passing a `--features`
+flag.  Add one of:
+
+```bash
+--features cache-l2      # Redis only
+--features cache-l1      # Moka in-process only
+--features cache-l1-l2   # Two-tier
+```
 
 ### Logout Doesn't Work
 
-- **For Google/GitHub:** Use `DefaultLogoutHandler` (no `end_session_endpoint`)
-- **For Keycloak/Azure AD/Okta/Auth0:** Use `OidcLogoutHandler` with `end_session_endpoint`
+- **For Google / GitHub:** Use `DefaultLogoutHandler` (no `OAUTH_END_SESSION_ENDPOINT`)
+- **For Keycloak / Azure AD / Okta / Auth0:** Use `OidcLogoutHandler` with
+  `OAUTH_END_SESSION_ENDPOINT`
+
+---
 
 ## Production Deployment
 
 ### Security Checklist
 
 - [ ] Use HTTPS for all endpoints
-- [ ] Generate strong random `PRIVATE_COOKIE_KEY`
-- [ ] Store secrets in environment variables or secret manager
-- [ ] Use `CodeChallengeMethod::S256` (default)
-- [ ] Set appropriate `session_max_age` (e.g., 30 minutes)
+- [ ] Generate a strong random `PRIVATE_COOKIE_KEY` (`openssl rand -base64 64`)
+- [ ] Store secrets in environment variables or a secret manager
+- [ ] Use `CODE_CHALLENGE_METHOD=S256` (default)
+- [ ] Set appropriate `session_max_age` (e.g. 30 minutes)
 - [ ] Request only necessary OAuth scopes
 - [ ] Verify redirect URIs in provider settings
 - [ ] Enable secure cookies (automatic with HTTPS)
 
-### Environment Configuration
+### Cache Recommendations for Production
 
-```bash
-# Production .env
+| Scenario                          | Recommended feature |
+| --------------------------------- | ------------------- |
+| Single instance, no Redis         | `cache-l1`          |
+| Single instance, Redis available  | `cache-l1-l2`       |
+| Multi-instance, shared state      | `cache-l2` or `cache-l1-l2` |
+| Development / testing             | `cache-l1` (no infrastructure needed) |
+
+### Example Production `.env`
+
+```env
+# OAuth2
 OAUTH_REDIRECT_URI=https://yourapp.com/auth/callback
 POST_LOGOUT_REDIRECT_URI=https://yourapp.com
 PRIVATE_COOKIE_KEY=<generated-with-openssl-rand-base64-64>
-SESSION_MAX_AGE=30
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
+
+# Server
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080
+
+# Cache (two-tier example)
+REDIS_URL=redis://redis-host:6379/
+CACHE_TTL=1800
+L1_MAX_CAPACITY=10000
+L1_TTL_SEC=1800
+L1_TIME_TO_IDLE_SEC=600
 ```
+
+Run with:
+
+```bash
+cargo run --release --no-default-features --features cache-l1-l2
+```
+
+---
 
 ## Additional Resources
 
-- [Main README](../../README.md) - Library documentation
-- [API Documentation](../../DOCUMENTATION.md) - Complete API reference
-- [Quick Reference](../../QUICK_REFERENCE.md) - Common patterns
-- [Provider Examples](../../PROVIDER_EXAMPLES.md) - Detailed provider configs
+- [Main README](../../README.md) — Library documentation
+- [API Documentation](../../DOCUMENTATION.md) — Complete API reference
+- [Quick Reference](../../QUICK_REFERENCE.md) — Common patterns
+- [Provider Examples](../../PROVIDER_EXAMPLES.md) — Detailed provider configs
 
 ## License
 

--- a/examples/sample-server/src/cache.rs
+++ b/examples/sample-server/src/cache.rs
@@ -1,0 +1,103 @@
+//! Cache construction module.
+//!
+//! This module exposes a single [`build_cache`] function whose implementation
+//! is selected at compile time by the active cache feature flag:
+//!
+//! | Feature       | Cache type                          | External dependency |
+//! |---------------|-------------------------------------|---------------------|
+//! | `cache-l2`    | Redis (L2-only)                     | Redis server        |
+//! | `cache-l1`    | Moka (L1-only)                      | None                |
+//! | `cache-l1-l2` | Moka L1 + Redis L2 (two-tier)       | Redis server        |
+//!
+//! Enabling both `cache-l1` and `cache-l2` individually produces the same
+//! binary as enabling `cache-l1-l2`.
+//!
+//! ## Compile-time guard
+//!
+//! If no cache feature is active the crate will fail to compile with a clear
+//! error message pointing to the required feature flags.
+
+// ─── Guard: fail fast when no cache feature is selected ───────────────────────
+
+#[cfg(not(any(feature = "cache-l1", feature = "cache-l2")))]
+compile_error!(
+    "At least one cache feature must be enabled. Choose one of:\n\
+     --features cache-l1      (Moka in-process only - default)\n\
+     --features cache-l2      (Redis only)\n\
+     --features cache-l1-l2   (Moka L1 + Redis L2)"
+);
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+use std::sync::Arc;
+
+use axum_oidc_client::auth_cache::AuthCache;
+
+use crate::config::Args;
+
+// ─── Two-tier: Moka L1 + Redis L2 ────────────────────────────────────────────
+
+/// Build a **two-tier** [`AuthCache`] (Moka L1 in front of Redis L2).
+///
+/// Active when both `cache-l1` **and** `cache-l2` features are enabled
+/// (i.e. when `cache-l1-l2` is selected).
+///
+/// Read path: L1 → on miss → L2 → populate L1.
+/// Write path: L2 first (source of truth), then L1.
+#[cfg(all(feature = "cache-l1", feature = "cache-l2"))]
+pub fn build_cache(args: &Args) -> Arc<dyn AuthCache + Send + Sync> {
+    use axum_oidc_client::cache::{config::TwoTierCacheConfig, TwoTierAuthCache};
+    use axum_oidc_client::redis;
+
+    let redis_l2: Arc<dyn AuthCache + Send + Sync> =
+        Arc::new(redis::AuthCache::new(&args.redis_url, args.cache_ttl));
+
+    let config = TwoTierCacheConfig {
+        l1_max_capacity: args.l1_max_capacity,
+        l1_ttl_sec: args.l1_ttl_sec,
+        l1_time_to_idle_sec: args.l1_time_to_idle_sec,
+        enable_l1: true,
+    };
+
+    Arc::new(
+        TwoTierAuthCache::new(Some(redis_l2), config)
+            .expect("failed to build two-tier cache (Moka L1 + Redis L2)"),
+    )
+}
+
+// ─── L1-only: Moka in-process cache ──────────────────────────────────────────
+
+/// Build an **L1-only** [`AuthCache`] backed exclusively by Moka.
+///
+/// Active when `cache-l1` is enabled **without** `cache-l2`.
+/// No external backend is required.
+///
+/// > **Note:** `extend_auth_session` re-inserts the entry to reset its
+/// > wall-clock TTL to the configured `l1_ttl_sec`.  The exact `ttl`
+/// > argument cannot be honoured precisely in L1-only mode.
+#[cfg(all(feature = "cache-l1", not(feature = "cache-l2")))]
+pub fn build_cache(args: &Args) -> Arc<dyn AuthCache + Send + Sync> {
+    use axum_oidc_client::cache::{config::TwoTierCacheConfig, TwoTierAuthCache};
+
+    let config = TwoTierCacheConfig {
+        l1_max_capacity: args.l1_max_capacity,
+        l1_ttl_sec: args.l1_ttl_sec,
+        l1_time_to_idle_sec: args.l1_time_to_idle_sec,
+        enable_l1: true,
+    };
+
+    Arc::new(TwoTierAuthCache::new(None, config).expect("failed to build L1-only cache (Moka)"))
+}
+
+// ─── L2-only: Redis ───────────────────────────────────────────────────────────
+
+/// Build an **L2-only** [`AuthCache`] backed by Redis.
+///
+/// Active when `cache-l2` is enabled **without** `cache-l1`.
+/// Requires an external Redis server.
+#[cfg(all(feature = "cache-l2", not(feature = "cache-l1")))]
+pub fn build_cache(args: &Args) -> Arc<dyn AuthCache + Send + Sync> {
+    use axum_oidc_client::redis;
+
+    Arc::new(redis::AuthCache::new(&args.redis_url, args.cache_ttl))
+}

--- a/examples/sample-server/src/config.rs
+++ b/examples/sample-server/src/config.rs
@@ -3,8 +3,20 @@
 //! This module handles:
 //! - CLI argument parsing using clap
 //! - OAuth2 configuration building
+//! - Cache configuration (feature-gated)
 //! - Environment variable integration
 //! - Configuration validation and display
+//!
+//! ## Cache feature flags
+//!
+//! The active cache feature controls which CLI arguments and environment
+//! variables are available:
+//!
+//! | Feature       | Extra args                                              |
+//! |---------------|---------------------------------------------------------|
+//! | `cache-l2`    | `--redis-url`, `--cache-ttl`                            |
+//! | `cache-l1`    | `--l1-max-capacity`, `--l1-ttl-sec`, `--l1-tti-sec`     |
+//! | `cache-l1-l2` | all of the above                                        |
 
 use axum_oidc_client::{
     auth::{CodeChallengeMethod, OAuthConfiguration},
@@ -124,6 +136,74 @@ pub struct Args {
     /// Server port
     #[arg(short, long, env = "SERVER_PORT", default_value = "8080")]
     pub port: u16,
+
+    // ── L2 cache (Redis) args ─────────────────────────────────────────────────
+    /// Redis connection URL.
+    ///
+    /// Used when the `cache-l2` or `cache-l1-l2` feature is enabled.
+    #[cfg(feature = "cache-l2")]
+    #[arg(
+        long,
+        env = "REDIS_URL",
+        default_value = "redis://127.0.0.1/",
+        help = "Redis connection URL [cache-l2 / cache-l1-l2]"
+    )]
+    pub redis_url: String,
+
+    /// Time-to-live for Redis cache entries (seconds).
+    ///
+    /// Used when the `cache-l2` or `cache-l1-l2` feature is enabled.
+    #[cfg(feature = "cache-l2")]
+    #[arg(
+        long,
+        env = "CACHE_TTL",
+        default_value = "3600",
+        help = "Redis cache TTL in seconds [cache-l2 / cache-l1-l2]"
+    )]
+    pub cache_ttl: u64,
+
+    // ── L1 cache (Moka) args ──────────────────────────────────────────────────
+    /// Maximum number of entries held by the Moka L1 cache.
+    ///
+    /// Used when the `cache-l1` or `cache-l1-l2` feature is enabled.
+    #[cfg(feature = "cache-l1")]
+    #[arg(
+        long,
+        env = "L1_MAX_CAPACITY",
+        default_value = "10000",
+        help = "Moka L1 cache max capacity (entries) [cache-l1 / cache-l1-l2]"
+    )]
+    pub l1_max_capacity: u64,
+
+    /// Time-to-live for Moka L1 cache entries (seconds).
+    ///
+    /// Should match or slightly exceed the L2 TTL so that stale L1 hits never
+    /// shadow a fresher L2 entry for too long.
+    ///
+    /// Used when the `cache-l1` or `cache-l1-l2` feature is enabled.
+    #[cfg(feature = "cache-l1")]
+    #[arg(
+        long,
+        env = "L1_TTL_SEC",
+        default_value = "3600",
+        help = "Moka L1 cache TTL in seconds [cache-l1 / cache-l1-l2]"
+    )]
+    pub l1_ttl_sec: u64,
+
+    /// Time-to-idle for Moka L1 cache entries (seconds).
+    ///
+    /// When set, entries that have not been accessed for this duration are
+    /// evicted even if their TTL has not expired yet.  Leave unset to
+    /// disable idle-based eviction.
+    ///
+    /// Used when the `cache-l1` or `cache-l1-l2` feature is enabled.
+    #[cfg(feature = "cache-l1")]
+    #[arg(
+        long,
+        env = "L1_TIME_TO_IDLE_SEC",
+        help = "Moka L1 cache time-to-idle in seconds (optional) [cache-l1 / cache-l1-l2]"
+    )]
+    pub l1_time_to_idle_sec: Option<u64>,
 }
 
 /// Parse a code challenge method from a string.
@@ -271,5 +351,43 @@ impl Args {
         println!("  - Redirect URI: {}", self.redirect_uri);
         println!("  - Base Path: {}", self.base_path);
         println!("  - Scopes: {:?}", self.scopes);
+        self.print_cache_config();
+    }
+
+    /// Print the active cache configuration to stdout.
+    ///
+    /// The output is controlled by the active cache feature flag:
+    ///
+    /// - `cache-l1-l2` → Two-tier (Moka L1 + Redis L2) with all settings
+    /// - `cache-l1`    → L1-only (Moka) with L1 settings
+    /// - `cache-l2`    → L2-only (Redis) with Redis settings
+    pub fn print_cache_config(&self) {
+        // ── Mode banner ───────────────────────────────────────────────────────
+        #[cfg(all(feature = "cache-l1", feature = "cache-l2"))]
+        println!("\n🗄️  Cache: Two-tier (Moka L1 + Redis L2)");
+
+        #[cfg(all(feature = "cache-l1", not(feature = "cache-l2")))]
+        println!("\n🗄️  Cache: L1-only (Moka in-process, no external backend)");
+
+        #[cfg(all(feature = "cache-l2", not(feature = "cache-l1")))]
+        println!("\n🗄️  Cache: L2-only (Redis)");
+
+        // ── L2 (Redis) settings ───────────────────────────────────────────────
+        #[cfg(feature = "cache-l2")]
+        {
+            println!("  - Redis URL: {}", self.redis_url);
+            println!("  - Cache TTL: {}s", self.cache_ttl);
+        }
+
+        // ── L1 (Moka) settings ────────────────────────────────────────────────
+        #[cfg(feature = "cache-l1")]
+        {
+            println!("  - L1 Max Capacity: {} entries", self.l1_max_capacity);
+            println!("  - L1 TTL: {}s", self.l1_ttl_sec);
+            match self.l1_time_to_idle_sec {
+                Some(tti) => println!("  - L1 Time-to-Idle: {}s", tti),
+                None => println!("  - L1 Time-to-Idle: disabled"),
+            }
+        }
     }
 }

--- a/examples/sample-server/src/env.rs
+++ b/examples/sample-server/src/env.rs
@@ -13,6 +13,18 @@
 //! 3. `.env` (for shared defaults)
 //!
 //! Only the first file found is loaded.
+//!
+//! # Cache-related environment variables
+//!
+//! Additional variables are recognised depending on the active cache feature:
+//!
+//! | Variable            | Feature               | Description                          |
+//! |---------------------|-----------------------|--------------------------------------|
+//! | `REDIS_URL`         | `cache-l2`/`cache-l1-l2` | Redis connection URL              |
+//! | `CACHE_TTL`         | `cache-l2`/`cache-l1-l2` | Redis entry TTL in seconds        |
+//! | `L1_MAX_CAPACITY`   | `cache-l1`/`cache-l1-l2` | Moka max entries                  |
+//! | `L1_TTL_SEC`        | `cache-l1`/`cache-l1-l2` | Moka entry TTL in seconds         |
+//! | `L1_TIME_TO_IDLE_SEC` | `cache-l1`/`cache-l1-l2` | Moka idle-eviction timeout      |
 
 use std::{env, path::PathBuf};
 
@@ -40,6 +52,13 @@ use std::{env, path::PathBuf};
 /// Server Configuration:
 /// - `SERVER_HOST`
 /// - `SERVER_PORT`
+///
+/// Cache Configuration (feature-gated):
+/// - `REDIS_URL` *(cache-l2 / cache-l1-l2)*
+/// - `CACHE_TTL` *(cache-l2 / cache-l1-l2)*
+/// - `L1_MAX_CAPACITY` *(cache-l1 / cache-l1-l2)*
+/// - `L1_TTL_SEC` *(cache-l1 / cache-l1-l2)*
+/// - `L1_TIME_TO_IDLE_SEC` *(cache-l1 / cache-l1-l2)*
 ///
 /// # Returns
 ///
@@ -98,6 +117,31 @@ pub fn check_env_sources() -> Vec<String> {
     }
     if env::var("SERVER_PORT").is_ok() {
         sources.push("SERVER_PORT".to_string());
+    }
+
+    // ── Cache: L2 (Redis) ─────────────────────────────────────────────────────
+    #[cfg(feature = "cache-l2")]
+    {
+        if env::var("REDIS_URL").is_ok() {
+            sources.push("REDIS_URL".to_string());
+        }
+        if env::var("CACHE_TTL").is_ok() {
+            sources.push("CACHE_TTL".to_string());
+        }
+    }
+
+    // ── Cache: L1 (Moka) ─────────────────────────────────────────────────────
+    #[cfg(feature = "cache-l1")]
+    {
+        if env::var("L1_MAX_CAPACITY").is_ok() {
+            sources.push("L1_MAX_CAPACITY".to_string());
+        }
+        if env::var("L1_TTL_SEC").is_ok() {
+            sources.push("L1_TTL_SEC".to_string());
+        }
+        if env::var("L1_TIME_TO_IDLE_SEC").is_ok() {
+            sources.push("L1_TIME_TO_IDLE_SEC".to_string());
+        }
     }
 
     sources

--- a/examples/sample-server/src/main.rs
+++ b/examples/sample-server/src/main.rs
@@ -8,9 +8,35 @@
 //! - OAuth2/OIDC authentication with PKCE (Proof Key for Code Exchange)
 //! - Flexible configuration via CLI arguments or environment variables
 //! - Support for dotenv files (`.env`, `.env.local`, or custom via `DOTENV_FILE`)
-//! - Redis-based session caching
+//! - Feature-selectable cache backends (Redis L2, Moka L1, or two-tier)
 //! - Protected and public routes
 //! - Configurable logout handlers (default or OIDC)
+//!
+//! ## Cache Feature Flags
+//!
+//! The cache backend is selected at **compile time** via Cargo feature flags:
+//!
+//! | Feature       | Cache type                    | External dependency |
+//! |---------------|-------------------------------|---------------------|
+//! | `cache-l1`    | Moka in-process only *(default)* | None             |
+//! | `cache-l2`    | Redis only                    | Redis server        |
+//! | `cache-l1-l2` | Moka L1 + Redis L2 (two-tier) | Redis server        |
+//!
+//! ### Selecting a cache backend
+//!
+//! ```bash
+//! # Default: Moka in-process only (no external backend required)
+//! cargo run
+//!
+//! # Explicit Moka in-process only
+//! cargo run --no-default-features --features cache-l1
+//!
+//! # Redis only
+//! cargo run --no-default-features --features cache-l2
+//!
+//! # Two-tier: Moka L1 in front of Redis L2
+//! cargo run --no-default-features --features cache-l1-l2
+//! ```
 //!
 //! ## Usage
 //!
@@ -65,55 +91,24 @@
 //!
 //! ## Modules
 //!
+//! - [`cache`]  - Feature-gated cache construction
 //! - [`config`] - Configuration and CLI argument handling
-//! - [`env`] - Environment variable loading and management
+//! - [`env`]    - Environment variable loading and management
 //! - [`routes`] - Application route handlers
 
 use axum::{routing::get, Router};
 
 use axum_oidc_client::{
     auth::{AuthLayer, LogoutHandler},
-    auth_cache::AuthCache,
     logout::{handle_default_logout::DefaultLogoutHandler, handle_oidc_logout::OidcLogoutHandler},
 };
 use clap::Parser;
 use std::{net::SocketAddr, sync::Arc};
 
+mod cache;
 mod config;
 mod env;
 mod routes;
-
-/// Create a Redis-based authentication cache.
-///
-/// This function initializes a Redis cache for storing authentication state,
-/// session data, and tokens.
-///
-/// # Configuration
-///
-/// - **Redis URL**: `redis://127.0.0.1/` (default Redis instance)
-/// - **TTL**: 3600 seconds (1 hour)
-///
-/// # Returns
-///
-/// An `Arc` containing a thread-safe, sendable cache implementation.
-///
-/// # Examples
-///
-/// ```no_run
-/// # use axum_oidc_client::auth_cache::AuthCache;
-/// # use std::sync::Arc;
-/// # fn create_redis_cache() -> Arc<dyn AuthCache + Send + Sync> {
-/// #     use axum_oidc_client::redis;
-/// #     Arc::new(redis::AuthCache::new("redis://127.0.0.1/", 3600))
-/// # }
-/// let cache = create_redis_cache();
-/// // Use cache with AuthLayer
-/// ```
-fn create_redis_cache() -> Arc<dyn AuthCache + Send + Sync> {
-    use axum_oidc_client::redis;
-
-    Arc::new(redis::AuthCache::new("redis://127.0.0.1/", 3600))
-}
 
 /// Main application entry point.
 ///
@@ -121,52 +116,65 @@ fn create_redis_cache() -> Arc<dyn AuthCache + Send + Sync> {
 /// 1. Loads environment variables from dotenv files
 /// 2. Parses command-line arguments and environment variables
 /// 3. Builds OAuth2 configuration
-/// 4. Initializes Redis cache for session storage
-/// 5. Sets up logout handler (OIDC or default)
-/// 6. Creates Axum router with authentication middleware
+/// 4. Initializes the auth cache (backend selected by active cargo feature)
+/// 5. Sets up the logout handler (OIDC or default)
+/// 6. Creates the Axum router with the authentication middleware
 /// 7. Starts the HTTP server
+///
+/// # Cache selection
+///
+/// The cache backend is chosen at compile time:
+///
+/// - **`cache-l1`** *(default)* – Moka in-process cache; no external backend required.
+/// - **`cache-l2`** – Redis only.
+/// - **`cache-l1-l2`** – Two-tier: Moka L1 in front of Redis L2.
 ///
 /// # Panics
 ///
 /// This function will panic if:
 /// - OAuth configuration cannot be built
+/// - The cache cannot be initialised (e.g. invalid Redis URL)
 /// - Socket address cannot be parsed
 /// - Server fails to bind to the specified address
-/// - Server fails to start
 #[tokio::main]
 async fn main() {
-    // Load environment variables from dotenv files
+    // Load environment variables from dotenv files.
     // Priority: DOTENV_FILE env var > .env.local > .env
     let using_dotenv = env::load_dotenv();
 
-    // Parse command-line arguments (will use env vars from .env as fallbacks)
+    // Parse command-line arguments (env vars from the dotenv file are already
+    // available as fallbacks at this point).
     let args = config::Args::parse();
 
-    // Check which settings are from environment variables
+    // Record which settings came from environment variables so we can report
+    // them to the operator in the startup banner.
     let from_env = env::check_env_sources();
 
-    // Build OAuth configuration from CLI arguments
+    // Build the OAuth2 / OIDC configuration from the parsed arguments.
     let config = args
         .build_oauth_config()
         .expect("Failed to build OAuth configuration");
 
-    let cache = create_redis_cache();
+    // Build the auth cache.  The concrete implementation is chosen at compile
+    // time by the active cache feature flag (cache-l2 / cache-l1 / cache-l1-l2).
+    let cache = cache::build_cache(&args);
+
     let config_arc = Arc::new(config);
 
-    // Select appropriate logout handler based on configuration
+    // Select the appropriate logout handler based on configuration.
     let logout_handler: Arc<dyn LogoutHandler> = match config_arc.end_session_endpoint.as_ref() {
         Some(end_session_endpoint) => Arc::new(OidcLogoutHandler::new(end_session_endpoint)),
         None => Arc::new(DefaultLogoutHandler),
     };
 
-    // Build application with routes and authentication layer
+    // Build the application router with authentication middleware.
     let app = Router::new()
         .route("/", get(routes::home::home))
         .route("/home", get(routes::home::home))
         .route("/protected", get(routes::protected::protected))
         .layer(AuthLayer::new(config_arc, cache, logout_handler));
 
-    // Define the address to bind to from CLI arguments
+    // Resolve the bind address from CLI arguments.
     let addr: SocketAddr = format!("{host}:{port}", host = args.host, port = args.port)
         .parse()
         .expect("Failed to parse socket address");
@@ -177,17 +185,17 @@ async fn main() {
         port = args.port
     );
     println!("Routes:");
-    println!("  - GET /         (home)");
-    println!("  - GET /home     (home)");
+    println!("  - GET /          (home – public)");
+    println!("  - GET /home      (home – public)");
     println!("  - GET /protected (protected route)");
-    println!("  - GET /auth/logout (logout and redirect to home)");
-    println!("  - GET /auth/logout?redirect=/path (logout and redirect to custom path)");
+    println!("  - GET /auth/logout                    (logout → home)");
+    println!("  - GET /auth/logout?redirect=/path     (logout → custom path)");
 
-    // Display configuration information
+    // Display the full configuration including the active cache backend.
     args.print_config();
     env::print_config_sources(&from_env, using_dotenv.as_ref());
 
-    // Create and run the server
+    // Start the server.
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("Failed to bind to address");

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -18,6 +18,8 @@
 //!     auth::{AuthLayer, CodeChallengeMethod},
 //!     auth_builder::OAuthConfigurationBuilder,
 //!     auth_cache::AuthCache,
+//!     // `TwoTierAuthCache` requires the `moka-cache` feature (enabled by default).
+//!     cache::{TwoTierAuthCache, config::TwoTierCacheConfig},
 //!     logout::handle_default_logout::DefaultLogoutHandler,
 //! };
 //! use std::sync::Arc;
@@ -31,16 +33,19 @@
 //!     .with_redirect_uri("http://localhost:8080/auth/callback")
 //!     .with_private_cookie_key("secret-key")
 //!     .with_scopes(vec!["openid", "email"])
+//!     .with_post_logout_redirect_uri("/")
+//!     .with_session_max_age(3600)
 //!     .build()?;
 //!
-//! # #[cfg(feature = "redis")]
+//! // Create an L1-only in-memory cache (requires the `moka-cache` feature).
+//! // For Redis, enable the `redis` feature and use `axum_oidc_client::redis::AuthCache`.
 //! let cache: Arc<dyn AuthCache + Send + Sync> = Arc::new(
-//!     axum_oidc_client::redis::AuthCache::new("redis://127.0.0.1/", 3600)
+//!     TwoTierAuthCache::new(None, TwoTierCacheConfig::default())?
 //! );
 //!
 //! let logout_handler = Arc::new(DefaultLogoutHandler);
 //!
-//! let app = Router::new()
+//! let app: Router<()> = Router::new()
 //!     .route("/", get(|| async { "Hello!" }))
 //!     .layer(AuthLayer::new(Arc::new(config), cache, logout_handler));
 //! # Ok(())
@@ -220,6 +225,8 @@ impl From<CodeChallengeMethod> for Method {
 ///     .with_redirect_uri("http://localhost:8080/auth/callback")
 ///     .with_private_cookie_key("secret-key-at-least-32-bytes")
 ///     .with_scopes(vec!["openid", "email", "profile"])
+///     .with_post_logout_redirect_uri("/")
+///     .with_session_max_age(30)
 ///     .build()?;
 /// # Ok(())
 /// # }

--- a/src/auth_builder.rs
+++ b/src/auth_builder.rs
@@ -17,6 +17,7 @@
 //!     .with_redirect_uri("http://localhost:8080/auth/callback")
 //!     .with_private_cookie_key("your-secret-key-at-least-32-bytes")
 //!     .with_scopes(vec!["openid", "email", "profile"])
+//!     .with_post_logout_redirect_uri("/")
 //!     .with_session_max_age(30) // 30 minutes
 //!     .with_token_max_age(5)    // 5 minutes
 //!     .build()?;
@@ -99,6 +100,8 @@ impl Display for Scopes {
 ///     .with_authorization_endpoint("https://provider.com/oauth/authorize")
 ///     .with_token_endpoint("https://provider.com/oauth/token")
 ///     .with_private_cookie_key("secret-key-min-32-bytes-long")
+///     .with_post_logout_redirect_uri("/")
+///     .with_session_max_age(30)
 ///     .with_code_challenge_method(CodeChallengeMethod::S256)
 ///     .build()?;
 /// # Ok(())

--- a/src/auth_session.rs
+++ b/src/auth_session.rs
@@ -92,7 +92,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// async fn check_session(session: AuthSession) -> String {
 ///     let now = Local::now();
-///     let is_expired = session.expires <= now;
+///     let is_expired = session.expires.map(|exp| exp <= now).unwrap_or(false);
 ///
 ///     // Note: When using the extractor, tokens are auto-refreshed
 ///     // so is_expired will typically be false

--- a/src/cache/config.rs
+++ b/src/cache/config.rs
@@ -1,0 +1,110 @@
+//! Cache configuration types.
+//!
+//! This module defines configuration structs used to tune the behaviour of the
+//! two-tier caching system.
+
+/// Configuration for the two-tier (L1 Moka + L2) auth cache.
+///
+/// # Example
+///
+/// ```rust
+/// use axum_oidc_client::cache::config::TwoTierCacheConfig;
+///
+/// let config = TwoTierCacheConfig {
+///     l1_max_capacity: 5_000,
+///     l1_ttl_sec: 1800,
+///     l1_time_to_idle_sec: Some(600),
+///     enable_l1: true,
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct TwoTierCacheConfig {
+    /// Maximum number of entries held by the Moka L1 cache.
+    ///
+    /// When this limit is reached the cache evicts the least-recently-used
+    /// entries to make room for new ones.
+    ///
+    /// Default: `10_000`
+    pub l1_max_capacity: u64,
+
+    /// Time-to-live for L1 cache entries, in seconds.
+    ///
+    /// Entries are evicted after this duration regardless of access patterns.
+    /// Should be set to match or slightly exceed the L2 cache TTL so that a
+    /// stale L1 hit never shadows a fresher L2 entry for too long.
+    ///
+    /// Default: `3600` (1 hour)
+    pub l1_ttl_sec: u64,
+
+    /// Optional time-to-idle for L1 cache entries, in seconds.
+    ///
+    /// When `Some`, entries that have not been accessed for this duration are
+    /// evicted even if their TTL has not expired yet.  Set to `None` to
+    /// disable idle-based eviction.
+    ///
+    /// Default: `None`
+    pub l1_time_to_idle_sec: Option<u64>,
+
+    /// Whether the L1 cache is active.
+    ///
+    /// Set to `false` to bypass Moka entirely and forward every operation
+    /// directly to the L2 cache.  Useful for testing or environments where
+    /// an in-process cache is undesirable.
+    ///
+    /// Default: `true`
+    pub enable_l1: bool,
+}
+
+impl Default for TwoTierCacheConfig {
+    fn default() -> Self {
+        Self {
+            l1_max_capacity: 10_000,
+            l1_ttl_sec: 3600,
+            l1_time_to_idle_sec: None,
+            enable_l1: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_values() {
+        let config = TwoTierCacheConfig::default();
+        assert_eq!(config.l1_max_capacity, 10_000);
+        assert_eq!(config.l1_ttl_sec, 3600);
+        assert_eq!(config.l1_time_to_idle_sec, None);
+        assert!(config.enable_l1);
+    }
+
+    #[test]
+    fn test_custom_values() {
+        let config = TwoTierCacheConfig {
+            l1_max_capacity: 500,
+            l1_ttl_sec: 60,
+            l1_time_to_idle_sec: Some(30),
+            enable_l1: false,
+        };
+        assert_eq!(config.l1_max_capacity, 500);
+        assert_eq!(config.l1_ttl_sec, 60);
+        assert_eq!(config.l1_time_to_idle_sec, Some(30));
+        assert!(!config.enable_l1);
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = TwoTierCacheConfig {
+            l1_max_capacity: 1_000,
+            l1_ttl_sec: 120,
+            l1_time_to_idle_sec: Some(60),
+            enable_l1: true,
+        };
+        let cloned = original.clone();
+        assert_eq!(cloned.l1_max_capacity, original.l1_max_capacity);
+        assert_eq!(cloned.l1_ttl_sec, original.l1_ttl_sec);
+        assert_eq!(cloned.l1_time_to_idle_sec, original.l1_time_to_idle_sec);
+        assert_eq!(cloned.enable_l1, original.enable_l1);
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,59 @@
+//! Two-tier authentication cache module.
+//!
+//! This module exposes a two-tier caching system that combines a fast
+//! in-process [Moka](https://crates.io/crates/moka) L1 cache with any
+//! [`AuthCache`](crate::auth_cache::AuthCache) implementation as the L2
+//! backend (e.g. Redis).
+//!
+//! ## Overview
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────┐
+//! │                 TwoTierAuthCache                    │
+//! │                                                     │
+//! │   ┌──────────────────┐    ┌─────────────────────┐  │
+//! │   │  L1 – Moka       │    │  L2 – AuthCache impl│  │
+//! │   │  (in-process)    │───▶│  (e.g. Redis)       │  │
+//! │   └──────────────────┘    └─────────────────────┘  │
+//! └─────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Cache-aside pattern
+//!
+//! | Operation      | L1 (Moka)                            | L2 (backend)                  |
+//! |----------------|--------------------------------------|-------------------------------|
+//! | **Read**       | Check first; on miss go to L2        | Read on L1 miss; populate L1  |
+//! | **Write**      | Write                                | Write                         |
+//! | **Invalidate** | Remove                               | Remove                        |
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig};
+//! use axum_oidc_client::auth_cache::AuthCache;
+//!
+//! # #[cfg(feature = "redis")]
+//! # async fn example() {
+//! let redis_cache: Arc<dyn AuthCache + Send + Sync> = Arc::new(
+//!     axum_oidc_client::redis::AuthCache::new("redis://127.0.0.1/", 3600)
+//! );
+//!
+//! let config = TwoTierCacheConfig {
+//!     l1_max_capacity: 10_000,
+//!     l1_ttl_sec: 3600,
+//!     l1_time_to_idle_sec: Some(1800),
+//!     enable_l1: true,
+//! };
+//!
+//! let cache = Arc::new(
+//!     TwoTierAuthCache::new(Some(redis_cache), config)
+//!         .expect("failed to build two-tier cache")
+//! );
+//! # }
+//! ```
+
+pub mod config;
+pub mod two_tier;
+
+pub use two_tier::TwoTierAuthCache;

--- a/src/cache/two_tier.rs
+++ b/src/cache/two_tier.rs
@@ -1,0 +1,972 @@
+//! Two-tier authentication cache implementation.
+//!
+//! This module provides [`TwoTierAuthCache`], a cache-aside wrapper that combines
+//! a fast in-process Moka L1 cache with an optional [`AuthCache`] implementation
+//! as the L2 backend (e.g. Redis).
+//!
+//! ## Operating modes
+//!
+//! | `enable_l1` | L2        | Mode         | Behaviour                                      |
+//! |-------------|-----------|--------------|------------------------------------------------|
+//! | `true`      | `Some(_)` | **Two-tier** | Sessions: L1 first, L2 on miss, write-through  |
+//! | `true`      | `None`    | **L1-only**  | Moka only; no external backend                 |
+//! | `false`     | `Some(_)` | **L2-only**  | All operations forwarded to the L2 backend     |
+//! | `false`     | `None`    | ❌ **Error** | [`TwoTierAuthCache::new`] returns `Err`        |
+//!
+//! ## Code verifier storage strategy
+//!
+//! Code verifiers are short-lived, single-use values (TTL ≈ 60 s) consumed
+//! entirely within a single OAuth PKCE round-trip.  When **L1 is enabled**,
+//! code verifiers are stored **exclusively in Moka** regardless of whether an
+//! L2 backend is also present.  This avoids unnecessary round-trips to Redis
+//! for data that will never be read from there.
+//!
+//! | L1 present | Code-verifier storage |
+//! |------------|-----------------------|
+//! | yes        | L1 only (L2 bypassed) |
+//! | no         | L2 only               |
+//!
+//! ## Auth-session cache-aside pattern (two-tier mode)
+//!
+//! Auth sessions are long-lived and must survive process restarts, so they
+//! continue to use the full cache-aside pattern when two tiers are present.
+//!
+//! | Operation      | L1 (Moka)                           | L2 (backend)                  |
+//! |----------------|-------------------------------------|-------------------------------|
+//! | **Read**       | Check first; on miss go to L2       | Read on L1 miss; populate L1  |
+//! | **Write**      | Write                               | Write first (source of truth) |
+//! | **Invalidate** | Remove                              | Remove                        |
+//! | **Extend TTL** | Evict (re-fetched on next read)     | Extend                        |
+//!
+//! ## L1-only `extend_auth_session` note
+//!
+//! Moka does not expose a per-entry TTL update API.  In L1-only mode,
+//! `extend_auth_session` re-inserts the current entry, which resets its
+//! wall-clock TTL to the configured `l1_ttl_sec`.  The `ttl` argument is
+//! forwarded to L2 when one is present; in L1-only mode it cannot be
+//! honoured precisely and the configured TTL is used instead.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::future::BoxFuture;
+use moka::future::Cache as MokaCache;
+
+use crate::auth_cache::AuthCache;
+use crate::auth_session::AuthSession;
+use crate::errors::Error;
+
+use super::config::TwoTierCacheConfig;
+
+// ─── Internal key helpers ─────────────────────────────────────────────────────
+
+/// Returns the Moka key used for a code-verifier entry.
+#[inline]
+fn cv_key(challenge_state: &str) -> String {
+    format!("cv:{challenge_state}")
+}
+
+/// Returns the Moka key used for an auth-session entry.
+#[inline]
+fn session_key(session_id: &str) -> String {
+    format!("session:{session_id}")
+}
+
+/// Extracts the bare identifier from a prefixed L1 key.
+///
+/// L1 keys carry a short type prefix (`cv:` or `session:`) so that both entry
+/// types can share a single Moka cache without key collisions.  When forwarding
+/// to L2 we strip the prefix because each L2 implementation applies its own
+/// prefixing internally (e.g. `code_verifier.{state}` for Redis).
+#[inline]
+fn key_tail(key: &str) -> &str {
+    match key.find(':') {
+        Some(pos) => &key[pos + 1..],
+        None => key,
+    }
+}
+
+// ─── L1 storage type ─────────────────────────────────────────────────────────
+
+/// Values stored in the Moka L1 cache.
+///
+/// Both code verifiers and auth sessions share one bounded `Cache<String, L1Entry>`
+/// so that a single capacity and eviction policy governs all in-memory entries.
+#[derive(Clone)]
+enum L1Entry {
+    CodeVerifier(String),
+    AuthSession(AuthSession),
+}
+
+// ─── TwoTierAuthCache ─────────────────────────────────────────────────────────
+
+/// A two-tier [`AuthCache`] that combines a Moka in-memory L1 cache with an
+/// optional L2 backend cache (e.g. Redis).
+///
+/// At least one tier must be active; construction fails with
+/// [`Error::CacheError`] when both are absent/disabled.
+///
+/// # Example – two-tier (Moka + Redis)
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig};
+/// use axum_oidc_client::auth_cache::AuthCache;
+///
+/// # #[cfg(feature = "redis")]
+/// # async fn example() -> Result<(), axum_oidc_client::errors::Error> {
+/// let redis: Arc<dyn AuthCache + Send + Sync> = Arc::new(
+///     axum_oidc_client::redis::AuthCache::new("redis://127.0.0.1/", 3600)
+/// );
+///
+/// let config = TwoTierCacheConfig {
+///     l1_max_capacity: 10_000,
+///     l1_ttl_sec: 3600,
+///     l1_time_to_idle_sec: Some(1800),
+///     enable_l1: true,
+/// };
+///
+/// let cache = Arc::new(TwoTierAuthCache::new(Some(redis), config)?);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Example – L1-only (Moka, no external backend)
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig};
+///
+/// # fn example() -> Result<(), axum_oidc_client::errors::Error> {
+/// let config = TwoTierCacheConfig::default(); // enable_l1: true
+/// let cache = Arc::new(TwoTierAuthCache::new(None, config)?);
+/// # Ok(())
+/// # }
+/// ```
+pub struct TwoTierAuthCache {
+    /// Moka async in-memory cache (L1).  `None` when `enable_l1` is `false`.
+    l1: Option<MokaCache<String, L1Entry>>,
+    /// Optional backing L2 cache (e.g. Redis).  `None` in L1-only mode.
+    l2: Option<Arc<dyn AuthCache + Send + Sync>>,
+    /// Configuration snapshot kept for introspection.
+    config: TwoTierCacheConfig,
+}
+
+impl TwoTierAuthCache {
+    /// Creates a new `TwoTierAuthCache`.
+    ///
+    /// # Arguments
+    ///
+    /// * `l2` – Optional L2 cache backend.  Pass `None` for L1-only operation.
+    /// * `config` – Configuration options controlling the L1 cache behaviour.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CacheError`] when `config.enable_l1` is `false` **and**
+    /// `l2` is `None`, because no cache tier would be active.
+    pub fn new(
+        l2: Option<Arc<dyn AuthCache + Send + Sync>>,
+        config: TwoTierCacheConfig,
+    ) -> Result<Self, Error> {
+        if !config.enable_l1 && l2.is_none() {
+            return Err(Error::CacheError(
+                "at least one cache tier must be configured: \
+                 set enable_l1 = true or provide an L2 backend"
+                    .to_string(),
+            ));
+        }
+
+        let l1 = if config.enable_l1 {
+            let mut builder = MokaCache::builder()
+                .max_capacity(config.l1_max_capacity)
+                .time_to_live(Duration::from_secs(config.l1_ttl_sec));
+
+            if let Some(tti) = config.l1_time_to_idle_sec {
+                builder = builder.time_to_idle(Duration::from_secs(tti));
+            }
+
+            Some(builder.build())
+        } else {
+            None
+        };
+
+        Ok(Self { l1, l2, config })
+    }
+
+    /// Returns a reference to the configuration used to build this cache.
+    pub fn config(&self) -> &TwoTierCacheConfig {
+        &self.config
+    }
+}
+
+// ─── AuthCache implementation ─────────────────────────────────────────────────
+
+impl AuthCache for TwoTierAuthCache {
+    // ── code_verifier ─────────────────────────────────────────────────────────
+    //
+    // Code verifiers are short-lived, single-use values (TTL ≈ 60 s) that are
+    // consumed entirely within a single OAuth PKCE round-trip.  When L1 is
+    // present they are stored exclusively in Moka — L2 is never read or
+    // written for code verifier operations.  This keeps the hot PKCE path
+    // fully in-process and avoids unnecessary network round-trips.
+    //
+    // When L1 is absent (L2-only mode) L2 is used as before.
+
+    fn get_code_verifier(
+        &self,
+        challenge_state: &str,
+    ) -> BoxFuture<'_, Result<Option<String>, Error>> {
+        let key = cv_key(challenge_state);
+        Box::pin(async move {
+            // L1 present → code verifiers live exclusively in L1; no L2 fallback.
+            if let Some(l1) = &self.l1 {
+                return Ok(match l1.get(&key).await {
+                    Some(L1Entry::CodeVerifier(v)) => Some(v),
+                    _ => None,
+                });
+            }
+
+            // L2-only mode: delegate to L2.
+            if let Some(l2) = &self.l2 {
+                return l2.get_code_verifier(key_tail(&key)).await;
+            }
+
+            Ok(None)
+        })
+    }
+
+    fn set_code_verifier(
+        &self,
+        challenge_state: &str,
+        code_verifier: &str,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        let key = cv_key(challenge_state);
+        let value = code_verifier.to_string();
+        Box::pin(async move {
+            // L1 present → store exclusively in L1; skip L2.
+            if let Some(l1) = &self.l1 {
+                l1.insert(key, L1Entry::CodeVerifier(value)).await;
+                return Ok(());
+            }
+
+            // L2-only mode: delegate to L2.
+            if let Some(l2) = &self.l2 {
+                l2.set_code_verifier(key_tail(&key), &value).await?;
+            }
+
+            Ok(())
+        })
+    }
+
+    fn invalidate_code_verifier(&self, challenge_state: &str) -> BoxFuture<'_, Result<(), Error>> {
+        let key = cv_key(challenge_state);
+        Box::pin(async move {
+            // L1 present → code verifier was stored only in L1; nothing to do on L2.
+            if let Some(l1) = &self.l1 {
+                l1.invalidate(&key).await;
+                return Ok(());
+            }
+
+            // L2-only mode: delegate to L2.
+            if let Some(l2) = &self.l2 {
+                l2.invalidate_code_verifier(key_tail(&key)).await?;
+            }
+
+            Ok(())
+        })
+    }
+
+    // ── auth_session ──────────────────────────────────────────────────────────
+
+    fn get_auth_session(
+        &self,
+        session_id: &str,
+    ) -> BoxFuture<'_, Result<Option<AuthSession>, Error>> {
+        let key = session_key(session_id);
+        Box::pin(async move {
+            // ① Check L1
+            if let Some(l1) = &self.l1 {
+                if let Some(L1Entry::AuthSession(s)) = l1.get(&key).await {
+                    return Ok(Some(s));
+                }
+            }
+
+            // ② L2 lookup (if present)
+            if let Some(l2) = &self.l2 {
+                let result = l2.get_auth_session(key_tail(&key)).await?;
+
+                // Populate L1 on L2 hit
+                if let (Some(l1), Some(ref s)) = (&self.l1, &result) {
+                    l1.insert(key, L1Entry::AuthSession(s.clone())).await;
+                }
+
+                return Ok(result);
+            }
+
+            Ok(None)
+        })
+    }
+
+    fn set_auth_session(
+        &self,
+        session_id: &str,
+        session: AuthSession,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        let key = session_key(session_id);
+        Box::pin(async move {
+            // Write to L2 first (source of truth when present)
+            if let Some(l2) = &self.l2 {
+                l2.set_auth_session(key_tail(&key), session.clone()).await?;
+            }
+
+            // Write to L1
+            if let Some(l1) = &self.l1 {
+                l1.insert(key, L1Entry::AuthSession(session)).await;
+            }
+
+            Ok(())
+        })
+    }
+
+    fn invalidate_auth_session(&self, session_id: &str) -> BoxFuture<'_, Result<(), Error>> {
+        let key = session_key(session_id);
+        Box::pin(async move {
+            if let Some(l1) = &self.l1 {
+                l1.invalidate(&key).await;
+            }
+
+            if let Some(l2) = &self.l2 {
+                l2.invalidate_auth_session(key_tail(&key)).await?;
+            }
+
+            Ok(())
+        })
+    }
+
+    fn extend_auth_session(&self, session_id: &str, ttl: i64) -> BoxFuture<'_, Result<(), Error>> {
+        // Strategy depends on which tiers are active:
+        //
+        // • Two-tier (L1 + L2):
+        //     Extend TTL on L2 (source of truth), then evict the L1 entry so
+        //     the next read re-fetches from L2 and re-populates L1.
+        //
+        // • L2-only:
+        //     Delegate directly to L2.
+        //
+        // • L1-only:
+        //     Moka does not support per-entry TTL updates.  Re-insert the
+        //     current entry to reset its wall-clock TTL to `l1_ttl_sec`.
+        //     If the entry is not found in L1 there is nothing to extend.
+        let key = session_key(session_id);
+        Box::pin(async move {
+            if let Some(l2) = &self.l2 {
+                // Extend on L2 (covers both two-tier and L2-only modes)
+                l2.extend_auth_session(key_tail(&key), ttl).await?;
+
+                // Evict the stale L1 entry; the next read will re-populate it
+                if let Some(l1) = &self.l1 {
+                    l1.invalidate(&key).await;
+                }
+            } else if let Some(l1) = &self.l1 {
+                // L1-only: re-insert to reset the entry's wall-clock TTL
+                if let Some(entry) = l1.get(&key).await {
+                    l1.insert(key, entry).await;
+                }
+                // If the entry is absent there is nothing to extend
+            }
+
+            Ok(())
+        })
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // ── Stub L2 cache ─────────────────────────────────────────────────────────
+
+    /// Simple in-memory stub that stands in for a real L2 backend (e.g. Redis).
+    /// Kept behind an `Arc` so tests can inspect state after operations.
+    #[derive(Default)]
+    struct StubL2 {
+        code_verifiers: Mutex<HashMap<String, String>>,
+        sessions: Mutex<HashMap<String, AuthSession>>,
+        /// Records the `ttl` argument passed to `extend_auth_session`.
+        session_ttls: Mutex<HashMap<String, i64>>,
+    }
+
+    impl StubL2 {
+        fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        /// Coerce `Arc<StubL2>` into the trait-object type expected by
+        /// `TwoTierAuthCache::new`.
+        fn as_dyn(this: &Arc<Self>) -> Arc<dyn AuthCache + Send + Sync> {
+            Arc::clone(this) as Arc<dyn AuthCache + Send + Sync>
+        }
+    }
+
+    impl AuthCache for StubL2 {
+        fn get_code_verifier(
+            &self,
+            challenge_state: &str,
+        ) -> BoxFuture<'_, Result<Option<String>, Error>> {
+            let result = self
+                .code_verifiers
+                .lock()
+                .unwrap()
+                .get(challenge_state)
+                .cloned();
+            Box::pin(async move { Ok(result) })
+        }
+
+        fn set_code_verifier(
+            &self,
+            challenge_state: &str,
+            code_verifier: &str,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            self.code_verifiers
+                .lock()
+                .unwrap()
+                .insert(challenge_state.to_string(), code_verifier.to_string());
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn invalidate_code_verifier(
+            &self,
+            challenge_state: &str,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            self.code_verifiers.lock().unwrap().remove(challenge_state);
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn get_auth_session(
+            &self,
+            session_id: &str,
+        ) -> BoxFuture<'_, Result<Option<AuthSession>, Error>> {
+            let result = self.sessions.lock().unwrap().get(session_id).cloned();
+            Box::pin(async move { Ok(result) })
+        }
+
+        fn set_auth_session(
+            &self,
+            session_id: &str,
+            session: AuthSession,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            self.sessions
+                .lock()
+                .unwrap()
+                .insert(session_id.to_string(), session);
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn invalidate_auth_session(&self, session_id: &str) -> BoxFuture<'_, Result<(), Error>> {
+            self.sessions.lock().unwrap().remove(session_id);
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn extend_auth_session(
+            &self,
+            session_id: &str,
+            ttl: i64,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            self.session_ttls
+                .lock()
+                .unwrap()
+                .insert(session_id.to_string(), ttl);
+            Box::pin(async move { Ok(()) })
+        }
+    }
+
+    // ── Fixture helpers ───────────────────────────────────────────────────────
+
+    fn l1_config() -> TwoTierCacheConfig {
+        TwoTierCacheConfig {
+            l1_max_capacity: 100,
+            l1_ttl_sec: 60,
+            l1_time_to_idle_sec: None,
+            enable_l1: true,
+        }
+    }
+
+    fn l2_only_config() -> TwoTierCacheConfig {
+        TwoTierCacheConfig {
+            l1_max_capacity: 100,
+            l1_ttl_sec: 60,
+            l1_time_to_idle_sec: None,
+            enable_l1: false,
+        }
+    }
+
+    /// Two-tier cache backed by `stub`.
+    fn make_two_tier(stub: &Arc<StubL2>) -> TwoTierAuthCache {
+        TwoTierAuthCache::new(Some(StubL2::as_dyn(stub)), l1_config()).unwrap()
+    }
+
+    /// L1-only cache (no L2).
+    fn make_l1_only() -> TwoTierAuthCache {
+        TwoTierAuthCache::new(None, l1_config()).unwrap()
+    }
+
+    /// L2-only cache backed by `stub`.
+    fn make_l2_only(stub: &Arc<StubL2>) -> TwoTierAuthCache {
+        TwoTierAuthCache::new(Some(StubL2::as_dyn(stub)), l2_only_config()).unwrap()
+    }
+
+    fn sample_session() -> AuthSession {
+        AuthSession {
+            id_token: "id_tok".to_string(),
+            access_token: "acc_tok".to_string(),
+            token_type: "Bearer".to_string(),
+            refresh_token: None,
+            scope: Some("openid".to_string()),
+            expires: None,
+        }
+    }
+
+    // ── construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_new_fails_when_both_tiers_absent() {
+        let result = TwoTierAuthCache::new(None, l2_only_config());
+        assert!(
+            result.is_err(),
+            "expected Err when enable_l1=false and l2=None"
+        );
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => unreachable!("expected Err but got Ok"),
+        };
+        let err_msg = format!("{:?}", err);
+        // The error must mention the missing cache configuration
+        assert!(
+            err_msg.to_lowercase().contains("cache"),
+            "error should mention cache: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_new_succeeds_l1_only() {
+        let cache = TwoTierAuthCache::new(None, l1_config());
+        assert!(cache.is_ok());
+        let cache = cache.unwrap();
+        assert!(cache.l1.is_some());
+        assert!(cache.l2.is_none());
+    }
+
+    #[test]
+    fn test_new_succeeds_l2_only() {
+        let stub = StubL2::new();
+        let cache = TwoTierAuthCache::new(Some(StubL2::as_dyn(&stub)), l2_only_config());
+        assert!(cache.is_ok());
+        let cache = cache.unwrap();
+        assert!(cache.l1.is_none());
+        assert!(cache.l2.is_some());
+    }
+
+    #[test]
+    fn test_new_succeeds_two_tier() {
+        let stub = StubL2::new();
+        let cache = TwoTierAuthCache::new(Some(StubL2::as_dyn(&stub)), l1_config());
+        assert!(cache.is_ok());
+        let cache = cache.unwrap();
+        assert!(cache.l1.is_some());
+        assert!(cache.l2.is_some());
+    }
+
+    // ── config accessor ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_config_accessor() {
+        let stub = StubL2::new();
+        let config = TwoTierCacheConfig {
+            l1_max_capacity: 42,
+            l1_ttl_sec: 99,
+            l1_time_to_idle_sec: Some(10),
+            enable_l1: true,
+        };
+        let cache = TwoTierAuthCache::new(Some(StubL2::as_dyn(&stub)), config).unwrap();
+        assert_eq!(cache.config().l1_max_capacity, 42);
+        assert_eq!(cache.config().l1_ttl_sec, 99);
+        assert_eq!(cache.config().l1_time_to_idle_sec, Some(10));
+        assert!(cache.config().enable_l1);
+    }
+
+    // ── key_tail ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_key_tail_cv() {
+        assert_eq!(key_tail("cv:abc123"), "abc123");
+    }
+
+    #[test]
+    fn test_key_tail_session() {
+        assert_eq!(key_tail("session:uuid-goes-here"), "uuid-goes-here");
+    }
+
+    #[test]
+    fn test_key_tail_no_prefix() {
+        assert_eq!(key_tail("nocolon"), "nocolon");
+    }
+
+    // ── two-tier: code_verifier ───────────────────────────────────────────────
+    //
+    // In two-tier mode code verifiers are stored exclusively in L1 (Moka).
+    // L2 is never read or written for code verifier operations.
+
+    #[tokio::test]
+    async fn test_two_tier_set_get_code_verifier() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+
+        cache.set_code_verifier("s1", "v1").await.unwrap();
+
+        // Readable via the cache (served from L1)
+        assert_eq!(
+            cache.get_code_verifier("s1").await.unwrap(),
+            Some("v1".to_string())
+        );
+        // L2 must NOT have been written to
+        assert_eq!(
+            stub.get_code_verifier("s1").await.unwrap(),
+            None,
+            "code verifier must not be written to L2 when L1 is present"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_get_code_verifier_miss() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+        assert_eq!(cache.get_code_verifier("ghost").await.unwrap(), None);
+    }
+
+    /// A code verifier written directly into L2 must NOT be visible through
+    /// the two-tier cache because L2 is bypassed for code verifier reads when
+    /// L1 is present.
+    #[tokio::test]
+    async fn test_two_tier_code_verifier_l2_write_invisible_to_cache() {
+        let stub = StubL2::new();
+
+        // Seed L2 directly (simulates a stale / out-of-band write)
+        stub.set_code_verifier("s2", "v2").await.unwrap();
+
+        let cache = make_two_tier(&stub);
+
+        // The two-tier cache must return None: L2 is not consulted for CVs.
+        assert_eq!(
+            cache.get_code_verifier("s2").await.unwrap(),
+            None,
+            "two-tier cache must not fall back to L2 for code verifiers"
+        );
+
+        // L1 must also be empty (no spurious population)
+        let l1 = cache.l1.as_ref().unwrap();
+        assert!(l1.get(&cv_key("s2")).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_invalidate_code_verifier() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+
+        cache.set_code_verifier("s3", "v3").await.unwrap();
+        cache.invalidate_code_verifier("s3").await.unwrap();
+
+        // Gone from the cache
+        assert_eq!(cache.get_code_verifier("s3").await.unwrap(), None);
+        // L2 was never written so this is trivially true, but assert for clarity
+        assert_eq!(stub.get_code_verifier("s3").await.unwrap(), None);
+    }
+
+    // ── two-tier: auth_session ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_two_tier_set_get_auth_session() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+        let session = sample_session();
+
+        cache
+            .set_auth_session("sess1", session.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cache.get_auth_session("sess1").await.unwrap(),
+            Some(session.clone())
+        );
+        assert_eq!(stub.get_auth_session("sess1").await.unwrap(), Some(session));
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_get_auth_session_miss() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+        assert_eq!(cache.get_auth_session("ghost").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_get_auth_session_populates_l1_from_l2() {
+        let stub = StubL2::new();
+        let session = sample_session();
+        stub.set_auth_session("sess2", session.clone())
+            .await
+            .unwrap();
+
+        let cache = make_two_tier(&stub);
+
+        assert_eq!(
+            cache.get_auth_session("sess2").await.unwrap(),
+            Some(session.clone())
+        );
+
+        let l1 = cache.l1.as_ref().unwrap();
+        let entry = l1.get(&session_key("sess2")).await;
+        assert!(matches!(entry, Some(L1Entry::AuthSession(s)) if s == session));
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_invalidate_auth_session() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+        let session = sample_session();
+
+        cache.set_auth_session("sess3", session).await.unwrap();
+        cache.invalidate_auth_session("sess3").await.unwrap();
+
+        assert_eq!(cache.get_auth_session("sess3").await.unwrap(), None);
+        assert_eq!(stub.get_auth_session("sess3").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_two_tier_extend_evicts_l1_and_delegates_to_l2() {
+        let stub = StubL2::new();
+        let cache = make_two_tier(&stub);
+        let session = sample_session();
+
+        cache.set_auth_session("sess4", session).await.unwrap();
+
+        // Entry must be in L1 after write
+        assert!(cache
+            .l1
+            .as_ref()
+            .unwrap()
+            .get(&session_key("sess4"))
+            .await
+            .is_some());
+
+        cache.extend_auth_session("sess4", 7200).await.unwrap();
+
+        // L1 entry must be evicted after extend
+        assert!(cache
+            .l1
+            .as_ref()
+            .unwrap()
+            .get(&session_key("sess4"))
+            .await
+            .is_none());
+
+        // TTL extension delegated to L2
+        assert_eq!(
+            stub.session_ttls.lock().unwrap().get("sess4").cloned(),
+            Some(7200)
+        );
+    }
+
+    // ── L1-only: code_verifier ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_l1_only_set_get_code_verifier() {
+        let cache = make_l1_only();
+
+        cache.set_code_verifier("s_l1", "v_l1").await.unwrap();
+
+        assert!(cache.l2.is_none());
+        assert_eq!(
+            cache.get_code_verifier("s_l1").await.unwrap(),
+            Some("v_l1".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_get_code_verifier_miss() {
+        let cache = make_l1_only();
+        assert_eq!(cache.get_code_verifier("absent").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_invalidate_code_verifier() {
+        let cache = make_l1_only();
+
+        cache.set_code_verifier("s_inv", "v_inv").await.unwrap();
+        cache.invalidate_code_verifier("s_inv").await.unwrap();
+
+        assert_eq!(cache.get_code_verifier("s_inv").await.unwrap(), None);
+    }
+
+    // ── L1-only: auth_session ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_l1_only_set_get_auth_session() {
+        let cache = make_l1_only();
+        let session = sample_session();
+
+        cache
+            .set_auth_session("l1_sess", session.clone())
+            .await
+            .unwrap();
+
+        assert!(cache.l2.is_none());
+        assert_eq!(
+            cache.get_auth_session("l1_sess").await.unwrap(),
+            Some(session)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_get_auth_session_miss() {
+        let cache = make_l1_only();
+        assert_eq!(cache.get_auth_session("absent").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_invalidate_auth_session() {
+        let cache = make_l1_only();
+        let session = sample_session();
+
+        cache.set_auth_session("l1_inv", session).await.unwrap();
+        cache.invalidate_auth_session("l1_inv").await.unwrap();
+
+        assert_eq!(cache.get_auth_session("l1_inv").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_extend_reinserts_entry() {
+        let cache = make_l1_only();
+        let session = sample_session();
+
+        cache
+            .set_auth_session("l1_ext", session.clone())
+            .await
+            .unwrap();
+
+        // Entry must be present before extend
+        assert!(cache
+            .l1
+            .as_ref()
+            .unwrap()
+            .get(&session_key("l1_ext"))
+            .await
+            .is_some());
+
+        // extend_auth_session should succeed without panicking
+        cache.extend_auth_session("l1_ext", 3600).await.unwrap();
+
+        // Entry should still be accessible after re-insertion
+        assert_eq!(
+            cache.get_auth_session("l1_ext").await.unwrap(),
+            Some(session)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_l1_only_extend_absent_entry_is_noop() {
+        let cache = make_l1_only();
+        // Extending a non-existent entry should not error
+        let result = cache.extend_auth_session("nonexistent", 3600).await;
+        assert!(result.is_ok());
+    }
+
+    // ── L2-only: code_verifier ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_l2_only_set_get_code_verifier() {
+        let stub = StubL2::new();
+        let cache = make_l2_only(&stub);
+
+        cache.set_code_verifier("s_l2", "v_l2").await.unwrap();
+
+        assert!(cache.l1.is_none());
+        assert_eq!(
+            cache.get_code_verifier("s_l2").await.unwrap(),
+            Some("v_l2".to_string())
+        );
+        assert_eq!(
+            stub.get_code_verifier("s_l2").await.unwrap(),
+            Some("v_l2".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_l2_only_invalidate_code_verifier() {
+        let stub = StubL2::new();
+        let cache = make_l2_only(&stub);
+
+        cache.set_code_verifier("s_l2_inv", "v").await.unwrap();
+        cache.invalidate_code_verifier("s_l2_inv").await.unwrap();
+
+        assert_eq!(cache.get_code_verifier("s_l2_inv").await.unwrap(), None);
+    }
+
+    // ── L2-only: auth_session ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_l2_only_set_get_auth_session() {
+        let stub = StubL2::new();
+        let cache = make_l2_only(&stub);
+        let session = sample_session();
+
+        cache
+            .set_auth_session("l2_sess", session.clone())
+            .await
+            .unwrap();
+
+        assert!(cache.l1.is_none());
+        assert_eq!(
+            cache.get_auth_session("l2_sess").await.unwrap(),
+            Some(session.clone())
+        );
+        assert_eq!(
+            stub.get_auth_session("l2_sess").await.unwrap(),
+            Some(session)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_l2_only_extend_auth_session() {
+        let stub = StubL2::new();
+        let cache = make_l2_only(&stub);
+        let session = sample_session();
+
+        cache.set_auth_session("l2_ext", session).await.unwrap();
+        cache.extend_auth_session("l2_ext", 9000).await.unwrap();
+
+        assert_eq!(
+            stub.session_ttls.lock().unwrap().get("l2_ext").cloned(),
+            Some(9000)
+        );
+    }
+
+    // ── TTI configuration ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cache_with_tti() {
+        let config = TwoTierCacheConfig {
+            l1_max_capacity: 50,
+            l1_ttl_sec: 120,
+            l1_time_to_idle_sec: Some(30),
+            enable_l1: true,
+        };
+        // Verify construction succeeds; TTI is enforced by Moka internally.
+        let cache = TwoTierAuthCache::new(None, config).unwrap();
+        assert!(cache.l1.is_some());
+        assert_eq!(cache.config().l1_time_to_idle_sec, Some(30));
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use axum::response::IntoResponse;
+use std::fmt;
 
 #[cfg(feature = "redis")]
 use redis::RedisError;
@@ -149,6 +150,50 @@ impl Error {
             axum::http::StatusCode::BAD_GATEWAY => Error::BadGateway(response_text),
             axum::http::StatusCode::SERVICE_UNAVAILABLE => Error::ServiceUnavailable(response_text),
             _ => Error::UnknownStatusCode(status.as_u16(), response_text),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::MissingCodeVerifier => write!(f, "Missing code verifier"),
+            Error::MissingPatameter(p) => write!(f, "Missing parameter: {p}"),
+            Error::NotValidUri(u) => write!(f, "Not a valid URI: {u}"),
+            Error::Request(e) => write!(f, "Reqwest error: {e}"),
+            Error::InvalidCodeResponse(e) => write!(f, "Invalid code response: {e}"),
+            Error::InvalidTokenResponse(e) => write!(f, "Invalid token response: {e}"),
+            Error::InvalidResponse(r) => write!(f, "Invalid response: {r}"),
+            Error::CacheError(e) => write!(f, "Cache error: {e}"),
+            Error::TokenRefreshFailed(e) => write!(f, "Token refresh failed: {e}"),
+            Error::BadRequest(m) => write!(f, "Bad request: {m}"),
+            Error::Unauthorized(m) => write!(f, "Unauthorized: {m}"),
+            Error::Forbidden(m) => write!(f, "Forbidden: {m}"),
+            Error::NotFound(m) => write!(f, "Not found: {m}"),
+            Error::TooManyRequests(m) => write!(f, "Too many requests: {m}"),
+            Error::InternalServerError(m) => write!(f, "Internal server error: {m}"),
+            Error::BadGateway(m) => write!(f, "Bad gateway: {m}"),
+            Error::ServiceUnavailable(m) => write!(f, "Service unavailable: {m}"),
+            Error::UnknownStatusCode(code, m) => write!(f, "HTTP {code}: {m}"),
+            Error::AuthCacheNotConfigured => write!(f, "AuthCache not configured"),
+            Error::OAuthConfigNotConfigured => write!(f, "OAuthConfiguration not configured"),
+            Error::HttpClientNotConfigured => write!(f, "HTTP Client not configured"),
+            Error::SessionNotFound => write!(f, "No active session found"),
+            Error::SessionExpired => write!(f, "Session expired or not found"),
+            Error::CacheAccessError(m) => write!(f, "Cache error: {m}"),
+            Error::SessionUpdateFailed(m) => write!(f, "Failed to update session in cache: {m}"),
+            Error::TokenRefreshFailedAuth(m) => write!(f, "Token expired and refresh failed: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Request(e) => Some(e),
+            Error::InvalidCodeResponse(e) => Some(e),
+            Error::InvalidTokenResponse(e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -48,8 +48,8 @@
 //!     // ID token and access token are automatically refreshed if expired
 //!     format!(
 //!         "Welcome! Your token expires at: {}\nScopes: {}",
-//!         session.expires,
-//!         session.scope
+//!         session.expires.map(|e| e.to_string()).unwrap_or_else(|| "(no expiry)".to_string()),
+//!         session.scope.as_deref().unwrap_or("(none)")
 //!     )
 //! }
 //! ```
@@ -61,8 +61,9 @@
 //!
 //! async fn api_call(token: AccessToken) -> String {
 //!     // Access token is automatically refreshed if expired
-//!     // Access the token string with *token
-//!     format!("Making API call with token: {}", &*token[..20])
+//!     // Access the token string with *token (safely truncated to 20 chars)
+//!     let prefix: String = token.chars().take(20).collect();
+//!     format!("Making API call with token: {}", prefix)
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //!     auth::{AuthLayer, CodeChallengeMethod},
 //!     auth_builder::OAuthConfigurationBuilder,
 //!     auth_cache::AuthCache,
+//!     // `TwoTierAuthCache` requires the `moka-cache` feature (enabled by default).
+//!     cache::{TwoTierAuthCache, config::TwoTierCacheConfig},
 //!     logout::handle_default_logout::DefaultLogoutHandler,
 //! };
 //! use std::sync::Arc;
@@ -36,19 +38,21 @@
 //!     .with_private_cookie_key("your-secret-key")
 //!     .with_scopes(vec!["openid", "email", "profile"])
 //!     .with_code_challenge_method(CodeChallengeMethod::S256)
+//!     .with_post_logout_redirect_uri("/")
+//!     .with_session_max_age(3600)
 //!     .build()?;
 //!
-//! // Create a cache implementation (using Redis in this example)
-//! # #[cfg(feature = "redis")]
+//! // Create an L1-only in-memory cache (requires the `moka-cache` feature).
+//! // For Redis, enable the `redis` feature and use `axum_oidc_client::redis::AuthCache`.
 //! let cache: Arc<dyn AuthCache + Send + Sync> = Arc::new(
-//!     axum_oidc_client::redis::AuthCache::new("redis://127.0.0.1/", 3600)
+//!     TwoTierAuthCache::new(None, TwoTierCacheConfig::default())?
 //! );
 //!
 //! // Create logout handler
 //! let logout_handler = Arc::new(DefaultLogoutHandler);
 //!
 //! // Build your application
-//! let app = Router::new()
+//! let app: Router<()> = Router::new()
 //!     .route("/", get(|| async { "Hello, World!" }))
 //!     .layer(AuthLayer::new(Arc::new(config), cache, logout_handler));
 //!
@@ -66,6 +70,7 @@
 //! - [`logout`]: Logout handler implementations (default and OIDC)
 //! - [`errors`]: Error types used throughout the library
 //! - [`redis`]: Redis-based cache implementation (requires `redis` feature)
+//! - [`cache`]: Two-tier cache combining Moka L1 with any L2 backend (requires `moka-cache` feature)
 //!
 //! ## Automatic ID Token and Access Token Refresh
 //!
@@ -111,6 +116,7 @@
 //! - `redis`: Enable Redis cache backend (default TLS)
 //! - `redis-rustls`: Enable Redis with rustls for TLS
 //! - `redis-native-tls`: Enable Redis with native-tls
+//! - `moka-cache`: Enable the two-tier in-memory L1 cache (Moka) wrapping any [`auth_cache::AuthCache`] L2 backend
 //!
 //! ## Examples
 //!
@@ -131,3 +137,6 @@ pub mod logout;
     feature = "redis-native-tls"
 ))]
 pub mod redis;
+
+#[cfg(feature = "moka-cache")]
+pub mod cache;


### PR DESCRIPTION
Implement a two-tier cache combining Moka L1 with an optional L2 backend, plus configuration types, module structure, and tests; update Cargo features and documentation references.

## Summary by Sourcery

Introduce a configurable two-tier authentication cache with Moka L1 and optional Redis L2, wire it into the sample server via feature flags, and update documentation, CLI, and tooling to support selecting cache backends.

New Features:
- Add a generic two-tier authentication cache (`TwoTierAuthCache`) that combines a Moka in-process L1 cache with an optional `AuthCache` L2 backend such as Redis.
- Expose cache configuration via `TwoTierCacheConfig` and a new `cache` module, with a default-enabled `moka-cache` feature.
- Provide a cache-construction module in the sample server that selects Redis-only, Moka-only, or two-tier caching at compile time based on Cargo features, plus corresponding CLI and environment configuration options.

Enhancements:
- Refine the sample server’s Makefile and startup logging to parameterise cache selection via a `FEATURES` variable and display the active cache configuration.
- Improve error ergonomics by implementing `Display` and `std::error::Error` for the library’s `Error` type and adjusting examples to use the new cache API.
- Adjust existing documentation, examples, and route listings to reflect the new cache backends, configuration patterns, and provider guidance.

Build:
- Change the main crate’s features to introduce a default `moka-cache` feature (replacing the old `moka` feature) and enable async support on the `moka` dependency.
- Update the sample server Cargo features so cache backends are selected via `cache-l1`, `cache-l2`, and `cache-l1-l2` flags, with `cache-l1` as the default.

Documentation:
- Expand the sample server README with detailed guidance on cache backend selection (Redis-only, Moka-only, two-tier), related CLI flags, env vars, Make targets, and production recommendations.
- Update crate-level and module-level rustdoc to document the new cache module, `TwoTierAuthCache`, `TwoTierCacheConfig`, and the `moka-cache` feature.

Tests:
- Add comprehensive unit tests for the two-tier cache covering L1-only, L2-only, and combined modes, including TTL extension semantics and configuration behaviour.

Chores:
- Bump crate version to 0.2.0 and record the new cache system and feature changes in the changelog.