### PR TITLE
9 callback redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2026-04-9
+## [0.5.0] - 2026-04-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`OAuthConfigurationBuilder::with_token_request_redirect_uri(bool)`**: controls whether
+  `redirect_uri` is included in the Authorization Code → Access Token exchange request
+  ([RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3)).  Defaults to
+  `true` (backward-compatible).  Set to `false` for providers such as Okta that reject a
+  redundant `redirect_uri` when only one redirect URI is registered on the application.
+
+- **`OAuthConfiguration::token_request_redirect_uri: bool`**: new field on the configuration
+  struct exposing the same setting; defaults to `true`.
+
 ## [0.4.0] - 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-04-9
 
 ### Added
 
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`OAuthConfiguration::token_request_redirect_uri: bool`**: new field on the configuration
   struct exposing the same setting; defaults to `true`.
+
+-- **`full`**: new added feature with `["authentication", "jwt", "moka-cache", "redis", "redis-rustls", "sql-cache-all"]`
 
 ## [0.4.0] - 2026-04-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RedSoftwareSystems/axum-oidc-client"
 
 [dependencies]
 tokio = { version = "1.41", features = ["full"] }
-reqwest = { version = "0.12.22", features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12.22", default-features = false, features = ["json"] }
 pkce-std = "0.2.1"
 serde_html_form = "0.2.7"
 axum-extra = { version = "0.10.0", features = [
@@ -57,9 +57,16 @@ tempfile = "3"
 #
 # Both are in `default` so a plain `[dependencies] axum-oidc-client = "…"`
 # gives users the complete feature set without any extra configuration.
-default = ["authentication", "jwt", "moka-cache"]
+default = ["authentication", "jwt", "moka-cache", "reqwest-rustls-tls"]
 
 authentication = []
+
+# ── reqwest TLS backends ──────────────────────────────────────────────────────
+# Exactly one should be enabled. `reqwest-rustls-tls` is the default.
+reqwest-rustls-tls          = ["reqwest/rustls-tls"]
+reqwest-native-tls          = ["reqwest/native-tls"]
+reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
+
 jwt = ["dep:jsonwebtoken", "dep:base64"]
 
 # ── Moka in-process L1 cache ──────────────────────────────────────────────────
@@ -81,4 +88,4 @@ sql-cache-sqlite   = ["authentication", "dep:sqlx", "sqlx?/sqlite"]
 sql-cache-all = ["sql-cache-postgres", "sql-cache-mysql", "sql-cache-sqlite"]
 
 # Convenience feature that enables every feature in the crate.
-full = ["authentication", "jwt", "moka-cache", "redis", "redis-rustls", "sql-cache-all"]
+full = ["authentication", "jwt", "moka-cache", "redis", "redis-native-tls", "redis-rustls", "sql-cache-all", "reqwest-rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ sql-cache-sqlite   = ["authentication", "dep:sqlx", "sqlx?/sqlite"]
 
 # Convenience feature that enables all three SQL backends at once (for tests).
 sql-cache-all = ["sql-cache-postgres", "sql-cache-mysql", "sql-cache-sqlite"]
+
+# Convenience feature that enables every feature in the crate.
+full = ["authentication", "jwt", "moka-cache", "redis", "redis-rustls", "sql-cache-all"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ moka = { version = "0.12.11", optional = true, features = ["future"]}
 chrono = {version = "0.4.42", features = ["serde"]}
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { version = "0.1" }
+html-escape = { version = "0.2", optional = true }
 
 # sqlx is pulled in only when at least one sql-cache-* feature is enabled.
 # The runtime is always tokio; the database driver is selected per feature.
@@ -59,7 +60,7 @@ tempfile = "3"
 # gives users the complete feature set without any extra configuration.
 default = ["authentication", "jwt", "moka-cache", "reqwest-rustls-tls"]
 
-authentication = []
+authentication = ["dep:html-escape"]
 
 # ── reqwest TLS backends ──────────────────────────────────────────────────────
 # Exactly one should be enabled. `reqwest-rustls-tls` is the default.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# axum-oidc-client API Documentation (v0.4.0)
+# axum-oidc-client API Documentation (v0.5.0)
 
 Complete API documentation and usage guide for the axum-oidc-client library.
 
@@ -1661,5 +1661,5 @@ The `AuthenticationLayer` (also accessible via the `AuthLayer` alias) adds these
 
 ---
 
-**Last Updated:** 2026-03-25
-**Version:** 0.4.0
+**Last Updated:** 2026-04-15
+**Version:** 0.5.0

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -451,6 +451,7 @@ Fluent API for building configurations.
 | `with_post_logout_redirect_uri(uri)` | No       | Set post-logout redirect                           |
 | `with_custom_ca_cert(path)`          | No       | Set custom CA certificate                          |
 | `with_token_max_age(seconds)`        | No       | Set token max age                                  |
+| `with_token_request_redirect_uri(bool)` | No    | Include `redirect_uri` in the token request (default: `true`; set `false` for providers that reject it) |
 | `build()`                            | -        | Build the configuration                            |
 
 > *When `with_issuer` is used, `with_authorization_endpoint` and `with_token_endpoint` are not
@@ -1616,6 +1617,30 @@ The `AuthenticationLayer` (also accessible via the `AuthLayer` alias) adds these
 > let expires = session.expires.map(|e| e.to_string()).unwrap_or_else(|| "(no expiry)".to_string());
 > let scope = session.scope.as_deref().unwrap_or("(none)");
 > ```
+
+**Issue: Token exchange fails with `invalid_request` or `redirect_uri mismatch` from the provider**
+
+> **Solution:**
+> Some providers (e.g. Okta, certain Azure AD configurations) reject the token-exchange
+> request when `redirect_uri` is included redundantly — typically when only one redirect URI
+> is registered on the application.  Set `with_token_request_redirect_uri(false)` on the
+> builder to omit the parameter:
+>
+> ```rust
+> let config = OAuthConfigurationBuilder::default()
+>     .with_issuer("https://your-provider.example.com").await?
+>     .with_client_id("your-client-id")
+>     .with_client_secret("your-client-secret")
+>     .with_redirect_uri("http://localhost:8080/auth/callback")
+>     .with_private_cookie_key(&env::var("COOKIE_KEY")?)
+>     .with_session_max_age(30)
+>     .with_token_request_redirect_uri(false)
+>     .build()?;
+> ```
+>
+> Per [RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3), `redirect_uri`
+> is required in the token request only when it was included in the authorization request, and
+> must be identical if present.  The default (`true`) includes it for maximum compatibility.
 
 **Issue: `JwtClaims` extractor returns 401 even though a token is sent**
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -6,7 +6,7 @@ A quick reference guide for common tasks and API usage.
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.4.0"
+axum-oidc-client = "0.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -211,8 +211,15 @@ OAuthConfigurationBuilder::default()
     .with_post_logout_redirect_uri("http://localhost:8080")
     .with_custom_ca_cert("/path/to/ca.pem")
     .with_token_max_age(300)
+    // .with_token_request_redirect_uri(false)  // omit redirect_uri in token request (e.g. Okta)
     .build()?
 ```
+
+### Provider Compatibility
+
+| Setting | Default | When to change |
+|---------|---------|----------------|
+| `with_token_request_redirect_uri(bool)` | `true` | Set `false` if the provider returns `invalid_request` during token exchange because it rejects a redundant `redirect_uri` (e.g. Okta with a single registered redirect URI) |
 
 ## Route Handlers
 

--- a/README.md
+++ b/README.md
@@ -497,8 +497,15 @@ let config = OAuthConfigurationBuilder::default()
     .with_redirect_uri("http://localhost:8080/auth/callback")
     .with_private_cookie_key("secret-key-min-32-bytes-long")
     .with_scopes(vec!["openid", "email", "profile"])
+    // Optional: set false if your provider rejects redirect_uri in the token request
+    // .with_token_request_redirect_uri(false)
     .build()?;
 ```
+
+> **Provider compatibility note:** By default `redirect_uri` is included in the token exchange
+> request (RFC 6749 §4.1.3).  Call `.with_token_request_redirect_uri(false)` if your provider
+> rejects redundant `redirect_uri` parameters during token exchange (e.g. Okta when only one
+> redirect URI is registered).
 
 #### `auth_cache`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive OAuth2/OIDC authentication library for Axum web applications with PKCE (Proof Key for Code Exchange) support and token auto refresh capabilities.
 
-[![Crates.io](https://img.shields.io/crates/v/axum-oidc-client.svg?version=0.3.0)](https://crates.io/crates/axum-oidc-client)
+[![Crates.io](https://img.shields.io/crates/v/axum-oidc-client.svg)](https://crates.io/crates/axum-oidc-client)
 [![Documentation](https://docs.rs/axum-oidc-client/badge.svg)](https://docs.rs/axum-oidc-client)
 [![License](https://img.shields.io/crates/l/axum-oidc-client.svg)](LICENSE)
 
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.3.0"
+axum-oidc-client = "0.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -50,22 +50,22 @@ tokio = { version = "1", features = ["full"] }
 ```toml
 [dependencies]
 # Default: includes authentication, jwt, and moka-cache features
-axum-oidc-client = "0.3.0"
+axum-oidc-client = "0.5"
 
 # With JWT validation + Redis cache backend
-axum-oidc-client = { version = "0.3.0", features = ["jwt", "redis"] }
+axum-oidc-client = { version = "0.5", features = ["jwt", "redis"] }
 
 # With Redis + two-tier cache (L1 Moka + L2 Redis)
-axum-oidc-client = { version = "0.3.0", features = ["moka-cache", "redis"] }
+axum-oidc-client = { version = "0.5", features = ["moka-cache", "redis"] }
 
 # With PostgreSQL cache backend
-axum-oidc-client = { version = "0.3.0", features = ["sql-cache-postgres"] }
+axum-oidc-client = { version = "0.5", features = ["sql-cache-postgres"] }
 
 # With SQLite cache backend (great for development)
-axum-oidc-client = { version = "0.3.0", features = ["sql-cache-sqlite"] }
+axum-oidc-client = { version = "0.5", features = ["sql-cache-sqlite"] }
 
 # With Moka L1 + PostgreSQL L2 two-tier cache
-axum-oidc-client = { version = "0.3.0", features = ["moka-cache", "sql-cache-postgres"] }
+axum-oidc-client = { version = "0.5", features = ["moka-cache", "sql-cache-postgres"] }
 ```
 
 ## Quick Start

--- a/examples/www-server/src/routes/home.rs
+++ b/examples/www-server/src/routes/home.rs
@@ -113,7 +113,7 @@ pub async fn home(OptionalIdToken(id_token): OptionalIdToken) -> impl IntoRespon
     } else {
         r#"
                     <a href="/resources">Resources</a>
-                    <a href="/auth">Login with OAuth2</a>
+                    <a href="/auth?redirect=/home">Login with OAuth2</a>
         "#
     };
 

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -182,7 +182,7 @@ impl Display for Scopes {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct OAuthConfigurationBuilder {
     /// Secret key for encrypting session cookies
     pub private_cookie_key: Option<Key>,
@@ -192,6 +192,8 @@ pub struct OAuthConfigurationBuilder {
     pub client_secret: Option<String>,
     /// Redirect URI for OAuth2 callback
     pub redirect_uri: Option<String>,
+    /// See [`OAuthConfiguration::token_request_redirect_uri`].
+    pub token_request_redirect_uri: bool,
     /// OAuth2 authorization endpoint URL
     pub authorization_endpoint: Option<String>,
     /// OAuth2 token endpoint URL
@@ -218,6 +220,30 @@ pub struct OAuthConfigurationBuilder {
     /// Tracks whether `with_scopes` was called explicitly so that `with_issuer`
     /// knows not to overwrite the scopes with the discovered values.
     scopes_explicit: bool,
+}
+
+impl Default for OAuthConfigurationBuilder {
+    fn default() -> Self {
+        Self {
+            private_cookie_key: None,
+            client_id: None,
+            client_secret: None,
+            redirect_uri: None,
+            token_request_redirect_uri: true,
+            authorization_endpoint: None,
+            token_endpoint: None,
+            end_session_endpoint: None,
+            post_logout_redirect_uri: None,
+            scopes: Scopes::default(),
+            code_challenge_method: CodeChallengeMethod::default(),
+            custom_ca_cert: None,
+            session_max_age: None,
+            token_max_age: None,
+            base_path: None,
+            code_challenge_method_explicit: false,
+            scopes_explicit: false,
+        }
+    }
 }
 
 impl OAuthConfigurationBuilder {
@@ -458,6 +484,30 @@ impl OAuthConfigurationBuilder {
     pub fn with_redirect_uri(self, redirect_uri: &str) -> Self {
         Self {
             redirect_uri: Some(redirect_uri.to_string()),
+            ..self
+        }
+    }
+
+    /// Control whether `redirect_uri` is included in the token exchange request.
+    ///
+    /// Per [RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3)
+    /// `redirect_uri` is required in the token request only when it was present in
+    /// the authorization request.  Set this to `false` when your provider rejects
+    /// redundant `redirect_uri` parameters.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_token_request_redirect_uri(false);
+    /// ```
+    pub fn with_token_request_redirect_uri(self, include: bool) -> Self {
+        Self {
+            token_request_redirect_uri: include,
             ..self
         }
     }
@@ -793,6 +843,7 @@ impl OAuthConfigurationBuilder {
             code_challenge_method: self.code_challenge_method,
             custom_ca_cert: self.custom_ca_cert,
             base_path: self.base_path.unwrap_or_else(|| "/auth".to_string()),
+            token_request_redirect_uri: self.token_request_redirect_uri,
         };
         Ok(layer)
     }

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -57,7 +57,7 @@ use axum::{
     extract::Request,
     response::{IntoResponse, Response},
 };
-use axum_extra::extract::{cookie::Key, PrivateCookieJar};
+use axum_extra::extract::{PrivateCookieJar, cookie::Key};
 use chrono::{Duration, Local};
 use futures_util::future::BoxFuture;
 use http::request::Parts;
@@ -98,7 +98,7 @@ use crate::{
         cache::AuthCache,
         router::{
             handle_auth::handle_auth,
-            handle_callback::{handle_callback, AccessTokenResponse},
+            handle_callback::{AccessTokenResponse, handle_callback},
             handle_default::handle_default,
         },
         session::AuthSession,
@@ -266,6 +266,17 @@ pub struct OAuthConfiguration {
     pub client_secret: String,
     /// Redirect URI for OAuth2 callback
     pub redirect_uri: String,
+    /// Whether to include `redirect_uri` in the token exchange request.
+    ///
+    /// Per [RFC 6749 §4.1.3](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3) the
+    /// `redirect_uri` parameter is **required** in the token request only when it was
+    /// included in the authorization request.  Some providers (e.g. Okta when the
+    /// redirect URI is the only one registered) reject the token request when
+    /// `redirect_uri` is sent redundantly.
+    ///
+    /// - `true` (default) – include `redirect_uri` in the token request.
+    /// - `false` – omit `redirect_uri` from the token request.
+    pub token_request_redirect_uri: bool,
     /// OAuth2 authorization endpoint URL
     pub authorization_endpoint: String,
     /// OAuth2 token endpoint URL
@@ -501,7 +512,19 @@ where
 
         match path.as_str() {
             p if p == auth_route => {
-                Box::pin(async move { Ok(dispatch_auth(configuration, cache).await) })
+                // Extract the optional `redirect` query parameter from the request URI.
+                // e.g. GET /auth?redirect=%2Fdashboard  →  post_login_redirect = Some("/dashboard")
+                let post_login_redirect = uri
+                    .query()
+                    .and_then(|qs| {
+                        serde_html_form::from_str::<std::collections::HashMap<String, String>>(qs)
+                            .ok()
+                    })
+                    .and_then(|map| map.get("redirect").cloned());
+
+                Box::pin(async move {
+                    Ok(dispatch_auth(configuration, cache, post_login_redirect).await)
+                })
             }
             p if p == callback_route => {
                 let (mut parts, _) = request.into_parts();
@@ -534,8 +557,9 @@ where
 async fn dispatch_auth(
     configuration: Arc<OAuthConfiguration>,
     cache: Arc<dyn AuthCache + Send + Sync>,
+    post_login_redirect: Option<String>,
 ) -> Response {
-    handle_auth(configuration, cache)
+    handle_auth(configuration, cache, post_login_redirect)
         .await
         .unwrap_or_else(IntoResponse::into_response)
 }

--- a/src/authentication/router/handle_auth.rs
+++ b/src/authentication/router/handle_auth.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::{
-    authentication::{cache::AuthCache, OAuthConfiguration},
+    authentication::{OAuthConfiguration, cache::AuthCache},
     errors::Error,
 };
 
@@ -42,6 +42,7 @@ fn create_auth_request(
 pub async fn handle_auth(
     configuration: Arc<OAuthConfiguration>,
     cache: Arc<dyn AuthCache + Send + Sync>,
+    post_login_redirect: Option<String>,
 ) -> Result<Response, Error> {
     let code_challenge_method: Method = configuration.code_challenge_method.to_owned().into();
     let (code_verifier, code_challenge) =
@@ -50,8 +51,22 @@ pub async fn handle_auth(
     let verifier = code_verifier.get().to_string();
     let state = Uuid::new_v4().to_string();
 
+    // Encode a safe redirect path into the state so the callback can recover it
+    // after the provider round-trip.  The `|` separator never appears in a UUID
+    // or a valid relative path, making splitting unambiguous.
+    //
+    // Security: only relative paths that start with `/` (but not `//`, which
+    // would be treated as a protocol-relative URL) are accepted.  Anything else
+    // is silently dropped in favour of the default `/` redirect.
+    let state_with_redirect = match post_login_redirect {
+        Some(path) if path.starts_with('/') && !path.starts_with("//") => {
+            format!("{}|{}", state, path)
+        }
+        _ => state.clone(),
+    };
+
     cache.set_code_verifier(&state, &verifier).await?;
-    let url = create_auth_request(&configuration, &code_challenge, &state)?;
+    let url = create_auth_request(&configuration, &code_challenge, &state_with_redirect)?;
 
     Ok(Redirect::temporary(&url).into_response())
 }

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -1,7 +1,7 @@
 use axum::response::{Html, IntoResponse, Response};
-use axum_extra::extract::{cookie::Cookie, PrivateCookieJar};
+use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
 
-use http::{request::Parts, StatusCode, Uri};
+use http::{StatusCode, Uri, request::Parts};
 use reqwest::{self, Client};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -41,38 +41,50 @@ async fn get_auth_tokens(
     cache: Arc<dyn AuthCache + Send + Sync>,
     client: Arc<Client>,
     uri: &Uri,
-) -> Result<AccessTokenResponse, Error> {
+) -> Result<(AccessTokenResponse, Option<String>), Error> {
     let querystring = uri.query();
     let query = querystring
         .map(|qs| serde_html_form::from_str::<CodeExchange>(qs).map_err(Error::InvalidCodeResponse))
         .ok_or(Error::MissingPatameter("code".to_owned()))
         .flatten()?;
 
+    // Split the state into the cache key (UUID) and optional post-login redirect path.
+    // Format: "<uuid>" or "<uuid>|<path>".
+    let (state_key, post_login_redirect) = match query.state.splitn(2, '|').collect::<Vec<_>>()[..]
+    {
+        [key, path] => (key.to_string(), Some(path.to_string())),
+        [key] => (key.to_string(), None),
+        _ => (query.state.clone(), None),
+    };
+
     let OAuthConfiguration {
         redirect_uri,
         client_id,
         token_endpoint,
         client_secret,
+        token_request_redirect_uri,
         ..
     } = configuration.as_ref();
 
     let verifier = cache
-        .get_code_verifier(&query.state)
+        .get_code_verifier(&state_key)
         .await?
         .ok_or(Error::MissingCodeVerifier)?;
 
     // Invalidate immediately after retrieval — the verifier is single-use.
     // This runs before the token exchange so that a network error or a
     // rejected exchange cannot be retried with the same verifier.
-    cache.invalidate_code_verifier(&query.state).await?;
+    cache.invalidate_code_verifier(&state_key).await?;
 
-    let params = [
+    let mut params: Vec<(&str, &str)> = vec![
         ("grant_type", "authorization_code"),
         ("code", &query.code),
-        ("redirect_uri", redirect_uri),
         ("client_id", client_id),
         ("code_verifier", &verifier),
     ];
+    if *token_request_redirect_uri {
+        params.push(("redirect_uri", redirect_uri));
+    }
 
     let url = reqwest::Url::parse(token_endpoint)
         .map_err(|_| Error::NotValidUri(token_endpoint.to_string()))?;
@@ -95,7 +107,7 @@ async fn get_auth_tokens(
         StatusCode::OK => {
             let auth_session = res.json::<AccessTokenResponse>().await?;
 
-            Ok(auth_session)
+            Ok((auth_session, post_login_redirect))
         }
         status => {
             let err = res.text().await?;
@@ -131,7 +143,7 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
 
     let id = Uuid::new_v4().to_string();
 
-    let token_response =
+    let (token_response, post_login_redirect) =
         get_auth_tokens(configuration.clone(), cache.clone(), client.clone(), &uri).await?;
 
     cache
@@ -146,14 +158,21 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
             .secure(true)
             .max_age(Duration::minutes(60)),
     );
+
+    // Belt-and-suspenders validation: re-check the redirect path even though
+    // handle_auth already validated it before embedding it in the state.  The
+    // provider echoes the state back verbatim, but a defensive check here
+    // prevents any open-redirect if the state were somehow tampered with.
+    let redirect_to = match post_login_redirect {
+        Some(path) if path.starts_with('/') && !path.starts_with("//") => path,
+        _ => "/".to_string(),
+    };
+
     Ok((
         jar,
-        Html(
-            r#"
-        <head>
-          <meta http-equiv="Refresh" content="0; URL=/" />
-        </head>"#,
-        ),
+        Html(format!(
+            r#"<head><meta http-equiv="Refresh" content="0; URL={redirect_to}" /></head>"#
+        )),
     )
         .into_response())
 }

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -50,11 +50,10 @@ async fn get_auth_tokens(
 
     // Split the state into the cache key (UUID) and optional post-login redirect path.
     // Format: "<uuid>" or "<uuid>|<path>".
-    let (state_key, post_login_redirect) = match query.state.splitn(2, '|').collect::<Vec<_>>()[..]
-    {
-        [key, path] => (key.to_string(), Some(path.to_string())),
-        [key] => (key.to_string(), None),
-        _ => (query.state.clone(), None),
+    let (state_key, post_login_redirect) = if let Some((key, path)) = query.state.split_once('|') {
+        (key.to_string(), Some(path.to_string()))
+    } else {
+        (query.state.clone(), None)
     };
 
     let OAuthConfiguration {

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -163,7 +163,9 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
     // provider echoes the state back verbatim, but a defensive check here
     // prevents any open-redirect if the state were somehow tampered with.
     let redirect_to = match post_login_redirect {
-        Some(path) if path.starts_with('/') && !path.starts_with("//") => path,
+        Some(path) if path.starts_with('/') && !path.starts_with("//") => {
+            html_escape::encode_safe(&path).to_string()
+        }
         _ => "/".to_string(),
     };
 

--- a/src/authentication/router/test_helpers.rs
+++ b/src/authentication/router/test_helpers.rs
@@ -9,7 +9,7 @@ use futures_util::future::BoxFuture;
 
 use crate::{
     authentication::{
-        cache::AuthCache, session::AuthSession, CodeChallengeMethod, OAuthConfiguration,
+        CodeChallengeMethod, OAuthConfiguration, cache::AuthCache, session::AuthSession,
     },
     errors::Error,
 };
@@ -77,6 +77,7 @@ pub(crate) fn create_test_config() -> OAuthConfiguration {
         client_id: "test-client".to_string(),
         client_secret: "test-secret".to_string(),
         redirect_uri: "http://localhost:8080/auth/callback".to_string(),
+        token_request_redirect_uri: true,
         authorization_endpoint: "http://localhost/auth".to_string(),
         token_endpoint: "http://localhost/token".to_string(),
         end_session_endpoint: None,


### PR DESCRIPTION
## Summary by Sourcery

Add configurable redirect handling and provider compatibility improvements for OAuth token exchange, and bump the crate to version 0.5.0 with updated features and documentation.

New Features:
- Introduce `token_request_redirect_uri` configuration option and `with_token_request_redirect_uri(bool)` builder method to control inclusion of `redirect_uri` in the token exchange request.
- Support optional post-login redirect paths via a `redirect` query parameter, propagated through OAuth state and enforced safely on callback.
- Add a `full` cargo feature that enables all crate features at once.
- Expose TLS backend selection for `reqwest` via dedicated cargo features with a rustls-based default.

Enhancements:
- Ensure callback handler validates post-login redirect paths defensively to avoid open redirects.
- Adjust OAuth callback HTML response to redirect to a configurable path rather than always `/`.
- Refine default implementation for `OAuthConfigurationBuilder` to include the new token request setting.

Build:
- Make `reqwest` use explicit TLS backend features instead of its default features, with `reqwest-rustls-tls` enabled by default.
- Update crate version to 0.5.0 across Cargo.toml and documentation references.

Documentation:
- Update README, DOCUMENTATION, QUICK_REFERENCE, and CHANGELOG for version 0.5.0, including guidance on `with_token_request_redirect_uri` for provider compatibility and new feature flags.

Tests:
- Adjust test helper configuration to set the new `token_request_redirect_uri` field.

Chores:
- Update example app login link to include a post-login redirect back to `/home`.