### PR TITLE
make axum dependency optional

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,12 @@
 # ── Oxigate devcontainer ─────────────────────────────────────────────────────
-# Base: Microsoft's official Rust devcontainer image on Debian 12 Bookworm.
+# Base: Microsoft's official Rust devcontainer image on Debian Trixie.
 # Provides: rustup, cargo, rust-analyzer, git, common dev utilities.
 #
 # Node.js and Docker CLI are installed via devcontainer features (see
 # devcontainer.json) rather than here, so this Dockerfile only handles
 # Rust-specific tooling and system packages.
-ARG RUST_VERSION=1
-FROM mcr.microsoft.com/devcontainers/rust:${RUST_VERSION}-bookworm
+ARG BASE_IMAGE=mcr.microsoft.com/devcontainers/rust:1-trixie
+FROM ${BASE_IMAGE}
 
 # ── System packages ───────────────────────────────────────────────────────────
 # Install in a single layer to minimise image size.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,14 +13,17 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "RUST_VERSION": "1"
+            "BASE_IMAGE": "mcr.microsoft.com/devcontainers/rust:1-trixie"
         },
-        "cacheFrom": "mcr.microsoft.com/devcontainers/rust:1-bookworm"
+        "cacheFrom": "mcr.microsoft.com/devcontainers/rust:1-trixie"
     },
     // ── Devcontainer features ─────────────────────────────────────────────────
     // Features are installed by the devcontainer CLI on top of the image,
     // independently of the Dockerfile, and are kept up to date automatically.
     "features": {
+        // Common utilities — declared explicitly so feature install order does not
+        // contain a pruned soft-dependency warning.
+        "ghcr.io/devcontainers/features/common-utils:2": {},
         // Node.js 22 LTS — installs node, npm, nvm inside the container.
         "ghcr.io/devcontainers/features/node:1": {
             "version": "22",
@@ -48,13 +51,9 @@
     ],
     // ── Mounts ────────────────────────────────────────────────────────────────
     "mounts": [
-        // Persist the Cargo registry and build cache across container rebuilds.
-        // This avoids re-downloading crates every time the image is rebuilt.
-        "source=oidc-client-cargo-registry,target=/home/vscode/.cargo/registry,type=volume",
-        "source=oidc-client-cargo-git,target=/home/vscode/.cargo/git,type=volume",
-        // Persist the compiled target directory so incremental builds survive
-        // container restarts without a full recompile.
-        "source=oidc-client-target,target=${containerWorkspaceFolder}/target,type=volume"
+      "source=${localEnv:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",
+      "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly",
+      "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
     ],
     // ── Non-root user ─────────────────────────────────────────────────────────
     // The base image creates a `vscode` user (UID 1000). Running as non-root
@@ -234,7 +233,7 @@
                     "pfx",
                     "handlebars",
                     "devcontainer",
-                    "bookworm"
+                    "trixie"
                 ]
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-26
+
+### Added
+
+- **`server` feature** *(default)*: new top-level feature that bundles all Axum/server-side dependencies — `axum`, `axum-extra`, `pkce-std`, `rand`, `chrono`, `time`, `uuid`, `http`, `tower`, `tracing`, and `tokio/full`. Previously these were unconditionally compiled; they are now gated behind this feature so WASM and library-only consumers can opt out.
+
+- **`wasm` feature**: enables JS-backed random source (`getrandom/js`) and `jwt` support. Select this feature instead of `default` when targeting `wasm32-unknown-unknown`. The `server` feature must not be enabled alongside `wasm`.
+
+- **reqwest TLS backend features**: explicit TLS selection for reqwest. Exactly one should be enabled:
+  - `reqwest-rustls-tls` *(default)* — rustls TLS (was previously implicit)
+  - `reqwest-native-tls` — system native-tls
+  - `reqwest-native-tls-vendored` — vendored native-tls
+
+### Changed
+
+- **`default` feature set** updated from `["authentication", "jwt", "moka-cache"]` to `["server", "authentication", "jwt", "moka-cache", "reqwest-rustls-tls"]`. Existing server applications are unaffected; the new `server` and `reqwest-rustls-tls` gates were previously always-on.
+
+- **`full` feature** now explicitly includes `reqwest-rustls-tls`.
+
 ## [0.5.0] - 2026-04-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"
@@ -9,31 +9,31 @@ homepage = "https://github.com/RedSoftwareSystems/axum-oidc-client"
 repository = "https://github.com/RedSoftwareSystems/axum-oidc-client"
 
 [dependencies]
-tokio = { version = "1.41", features = ["full"] }
+tokio = { version = "1.41" }
 reqwest = { version = "0.12.22", default-features = false, features = ["json"] }
-pkce-std = "0.2.1"
+pkce-std = { version = "0.2.1", optional = true }
 serde_html_form = "0.2.7"
-axum-extra = { version = "0.10.0", features = [
+axum-extra = { version = "0.10.0", optional = true, features = [
     "cookie",
     "cookie-private",
     "cookie-signed",
 ] }
-axum = { version = "0.8.6", features = ["macros"] }
+axum = { version = "0.8.6", optional = true, features = ["macros"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-rand = { version = "0.9.1" }
-http = { version = "1.2.0" }
+rand = { version = "0.9.1", optional = true}
+http = { version = "1.2.0", optional = true }
 futures-util = { version = "0.3.31" }
-tower = { version = "0.5.2" }
+tower = { version = "0.5.2", optional = true }
 
 urlencoding = "2.1"
-uuid = { version = "1.18.1", features = ["v4"] }
-time = "0.3.44"
+uuid = { version = "1.18.1", optional = true, features = ["v4"] }
+time = { version = "0.3.44", optional = true}
 redis = { version = "1.0.0-rc.3", optional = true, features = ["tokio-comp", "connection-manager"]}
 moka = { version = "0.12.11", optional = true, features = ["future"]}
-chrono = {version = "0.4.42", features = ["serde"]}
+chrono = {version = "0.4.42", optional = true, features = ["serde"]}
 tokio-util = { version = "0.7", features = ["rt"] }
-tracing = { version = "0.1" }
+tracing = { version = "0.1", optional = true}
 html-escape = { version = "0.2", optional = true }
 
 # sqlx is pulled in only when at least one sql-cache-* feature is enabled.
@@ -43,6 +43,9 @@ sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "chrono"
 # jsonwebtoken and base64 are pulled in only when the `jwt` feature is enabled.
 jsonwebtoken = { version = "10.3", optional = true, features = ["rust_crypto"] }
 base64 = { version = "0.22", optional = true }
+
+# getrandom is pulled in only when the `wasm` feature is enabled.
+getrandom = { version = "0.2", optional = true }
 
 [dev-dependencies]
 mockito = "1"
@@ -58,7 +61,9 @@ tempfile = "3"
 #
 # Both are in `default` so a plain `[dependencies] axum-oidc-client = "…"`
 # gives users the complete feature set without any extra configuration.
-default = ["authentication", "jwt", "moka-cache", "reqwest-rustls-tls"]
+default = ["server", "authentication", "jwt", "moka-cache", "reqwest-rustls-tls"]
+
+server = ["axum", "axum-extra", "rand", "chrono", "pkce-std", "time", "uuid", "http", "tower", "tracing", "tokio/full"]
 
 authentication = ["dep:html-escape"]
 
@@ -87,6 +92,12 @@ sql-cache-sqlite   = ["authentication", "dep:sqlx", "sqlx?/sqlite"]
 
 # Convenience feature that enables all three SQL backends at once (for tests).
 sql-cache-all = ["sql-cache-postgres", "sql-cache-mysql", "sql-cache-sqlite"]
+
+# ── WASM support ─────────────────────────────────────────────────────────────
+# Enables the JS-backed random source required by getrandom on wasm32 targets,
+# plus JWT support.  Select this feature instead of `default` when targeting
+# wasm32-unknown-unknown.
+wasm = ["getrandom/js", "jwt"]
 
 # Convenience feature that enables every feature in the crate.
 full = ["authentication", "jwt", "moka-cache", "redis", "redis-native-tls", "redis-rustls", "sql-cache-all", "reqwest-rustls-tls"]

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# axum-oidc-client API Documentation (v0.5.0)
+# axum-oidc-client API Documentation (v0.6.0)
 
 Complete API documentation and usage guide for the axum-oidc-client library.
 
@@ -30,8 +30,17 @@ Complete API documentation and usage guide for the axum-oidc-client library.
 
 | Flag | Default | Description |
 |---|---|---|
+| `server` | ✅ | Bundles Axum, axum-extra, PKCE (`pkce-std`), `tower`, `tracing`, and `tokio/full`. Required for running as an HTTP server. Omit when targeting WASM. |
 | `authentication` | ✅ | Full OAuth2/OIDC stack (session management, cache, extractors, logout). Implied by every cache feature. |
 | `jwt` | ✅ | JWT validation via `JwtLayer`, `OidcClaims`, `JwtConfiguration`, `JwtConfigurationBuilder`. |
+
+### reqwest TLS backends (exactly one should be enabled)
+
+| Flag | Default | Description |
+|---|---|---|
+| `reqwest-rustls-tls` | ✅ | rustls TLS for reqwest (recommended). |
+| `reqwest-native-tls` | ❌ | System native-tls for reqwest. |
+| `reqwest-native-tls-vendored` | ❌ | Vendored native-tls for reqwest. |
 
 ### Cache backends (each implies `authentication`)
 
@@ -45,6 +54,12 @@ Complete API documentation and usage guide for the axum-oidc-client library.
 | `sql-cache-mysql` | ❌ | MySQL/MariaDB SQL cache backend. |
 | `sql-cache-sqlite` | ❌ | SQLite SQL cache backend. |
 | `sql-cache-all` | ❌ | All three SQL cache backends. |
+
+### WASM target
+
+| Flag | Default | Description |
+|---|---|---|
+| `wasm` | ❌ | Enables JS-backed random source (`getrandom/js`) and JWT support. Use instead of `default` when targeting `wasm32-unknown-unknown`. The `server` feature must **not** be enabled alongside `wasm`. |
 
 ## Core Concepts
 
@@ -309,11 +324,16 @@ let cache: Arc<dyn AuthCache + Send + Sync> = Arc::new(
 
 **Cache-aside behaviour:**
 
-| Operation  | L1 (Moka)                         | L2 (backend)                   |
-|------------|-----------------------------------|--------------------------------|
-| Read       | Check first; on miss, read L2     | Read on L1 miss; populate L1   |
-| Write      | Write                             | Write                          |
-| Invalidate | Remove                            | Remove                         |
+| Operation  | L1 (Moka)                         | L2 (backend)                            |
+|------------|-----------------------------------|-----------------------------------------|
+| Read       | Check first; on miss, read L2     | Read on L1 miss (auth sessions only)    |
+| Write (auth session) | Write                   | Write (source of truth)                 |
+| Write (code verifier) | Write (L1-only)        | **Not written** – PKCE verifiers are ephemeral |
+| Invalidate | Remove                            | Remove                                  |
+
+> **Note:** PKCE code verifiers are short-lived, single-use values. When L1
+> (Moka) is present they are stored exclusively in L1 to avoid unnecessary
+> round-trips to the L2 backend. In L2-only mode they are stored in L2.
 
 #### `TwoTierCacheConfig`
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -6,7 +6,7 @@ A quick reference guide for common tasks and API usage.
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.5"
+axum-oidc-client = "0.6"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -900,27 +900,35 @@ async fn test_refresh(session: AuthSession) -> String {
 
 | Feature | Default | Description |
 |---------|---------|-------------|
+| `server` | ✅ yes | Bundles Axum, axum-extra, PKCE, `tower`, `tracing`, `tokio/full`. Required for HTTP servers. Omit for WASM targets. |
 | `authentication` | ✅ yes | Core OAuth2/OIDC authentication layer (`AuthenticationLayer`, `AuthSession`, extractors) |
 | `jwt` | ✅ yes | Standalone JWT Bearer token validation (`JwtLayer`, `JwtClaims`, `OptionalJwtClaims`) |
+| `reqwest-rustls-tls` | ✅ yes | rustls TLS backend for reqwest (default TLS). |
+| `reqwest-native-tls` | ❌ no | System native-tls backend for reqwest. |
+| `reqwest-native-tls-vendored` | ❌ no | Vendored native-tls backend for reqwest. |
 | `moka-cache` | ✅ yes | In-memory L1 cache backed by Moka (`TwoTierAuthCache`) |
 | `redis` | ❌ no | Redis L2 cache backend |
 | `sql-cache-sqlite` | ❌ no | SQLite L2 cache backend (via SQLx) |
 | `sql-cache-postgres` | ❌ no | PostgreSQL L2 cache backend (via SQLx) |
 | `sql-cache-mysql` | ❌ no | MySQL/MariaDB L2 cache backend (via SQLx) |
 | `sql-cache-all` | ❌ no | All SQL backends (useful for testing) |
+| `wasm` | ❌ no | JS-backed random source + JWT. Use instead of `default` for `wasm32-unknown-unknown` targets. |
 
 ```toml
-# Default features (authentication + jwt + moka-cache)
-axum-oidc-client = "0.4.0"
+# Default features (server + authentication + jwt + moka-cache + reqwest-rustls-tls)
+axum-oidc-client = "0.6"
 
 # Add Redis support
-axum-oidc-client = { version = "0.4.0", features = ["redis"] }
+axum-oidc-client = { version = "0.6", features = ["redis"] }
 
 # JWT only (no OAuth2 session layer)
-axum-oidc-client = { version = "0.4.0", default-features = false, features = ["jwt"] }
+axum-oidc-client = { version = "0.6", default-features = false, features = ["jwt", "reqwest-rustls-tls"] }
 
 # Authentication only (no JWT layer)
-axum-oidc-client = { version = "0.4.0", default-features = false, features = ["authentication", "moka-cache"] }
+axum-oidc-client = { version = "0.6", default-features = false, features = ["server", "authentication", "moka-cache", "reqwest-rustls-tls"] }
+
+# WASM target (no server feature)
+axum-oidc-client = { version = "0.6", default-features = false, features = ["wasm", "reqwest-rustls-tls"] }
 ```
 
 ## Testing
@@ -958,5 +966,5 @@ openssl rand -hex 32
 
 ---
 
-**Version:** 0.4.0  
-**Last Updated:** 2026-03-04
+**Version:** 0.6.0  
+**Last Updated:** 2026-05-26

--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ tokio = { version = "1", features = ["full"] }
 
 #### Top-level (default)
 
-- `authentication` *(default)* – The full OAuth2/OIDC stack: `AuthenticationLayer`, session management, `AuthCache`, `OAuthConfigurationBuilder`, route handlers, extractors, and logout handlers.  Implied by every cache/backend feature.
+- `server` *(default)* – Bundles Axum, axum-extra, PKCE, tower, tracing, and tokio/full. Required for running as an HTTP server. Not needed for WASM targets.
+- `authentication` *(default)* – The full OAuth2/OIDC stack: `AuthenticationLayer`, session management, `AuthCache`, `OAuthConfigurationBuilder`, route handlers, extractors, and logout handlers. Implied by every cache/backend feature.
 - `jwt` *(default)* – JWT validation utilities: `JwtLayer`, `OidcClaims`, `JwtConfiguration`, `JwtConfigurationBuilder`, `JwtClaims`, `OptionalJwtClaims`.
+
+#### reqwest TLS backends (exactly one should be enabled)
+
+- `reqwest-rustls-tls` *(default)* – rustls TLS backend for reqwest.
+- `reqwest-native-tls` – native-tls backend for reqwest.
+- `reqwest-native-tls-vendored` – native-tls backend for reqwest (vendored OpenSSL).
 
 #### Cache backends (each implies `authentication`)
 
@@ -47,25 +54,32 @@ tokio = { version = "1", features = ["full"] }
 - `sql-cache-sqlite` – SQLite backend via sqlx
 - `sql-cache-all` – All three SQL backends at once (useful for testing)
 
+#### WASM
+
+- `wasm` – JS-backed random source + JWT. Use instead of `default` when targeting `wasm32-unknown-unknown`.
+
 ```toml
 [dependencies]
-# Default: includes authentication, jwt, and moka-cache features
-axum-oidc-client = "0.5"
+# Default: includes server, authentication, jwt, moka-cache, and reqwest-rustls-tls features
+axum-oidc-client = "0.6"
 
 # With JWT validation + Redis cache backend
-axum-oidc-client = { version = "0.5", features = ["jwt", "redis"] }
+axum-oidc-client = { version = "0.6", features = ["jwt", "redis"] }
 
 # With Redis + two-tier cache (L1 Moka + L2 Redis)
-axum-oidc-client = { version = "0.5", features = ["moka-cache", "redis"] }
+axum-oidc-client = { version = "0.6", features = ["moka-cache", "redis"] }
 
 # With PostgreSQL cache backend
-axum-oidc-client = { version = "0.5", features = ["sql-cache-postgres"] }
+axum-oidc-client = { version = "0.6", features = ["sql-cache-postgres"] }
 
 # With SQLite cache backend (great for development)
-axum-oidc-client = { version = "0.5", features = ["sql-cache-sqlite"] }
+axum-oidc-client = { version = "0.6", features = ["sql-cache-sqlite"] }
 
 # With Moka L1 + PostgreSQL L2 two-tier cache
-axum-oidc-client = { version = "0.5", features = ["moka-cache", "sql-cache-postgres"] }
+axum-oidc-client = { version = "0.6", features = ["moka-cache", "sql-cache-postgres"] }
+
+# WASM target (wasm32-unknown-unknown): disable defaults, enable wasm feature
+axum-oidc-client = { version = "0.6", default-features = false, features = ["wasm"] }
 ```
 
 ## Quick Start

--- a/src/authentication/moka/two_tier.rs
+++ b/src/authentication/moka/two_tier.rs
@@ -204,14 +204,14 @@ impl TwoTierAuthCache {
 impl AuthCache for TwoTierAuthCache {
     // ── code_verifier ─────────────────────────────────────────────────────────
     //
-    // Code verifiers use the same cache-aside pattern as auth sessions.
-    // In two-tier mode L2 is the source of truth (written first), and L1 acts
-    // as a read-through cache that is populated on an L2 hit.  This ensures
-    // correctness in multi-process deployments where the PKCE callback may
-    // arrive at a different instance than the one that started the flow.
+    // Code verifiers are short-lived, single-use PKCE values created during
+    // the authorization request and consumed immediately at the token endpoint.
+    // Because they are ephemeral and process-local, they are stored exclusively
+    // in L1 (Moka) when L1 is present — persisting them to an L2 backend
+    // (Redis, SQL) would add unnecessary I/O with no correctness benefit.
     //
     // In L1-only mode L2 is absent and Moka is used directly.
-    // In L2-only mode L1 is absent and all operations are delegated to L2.
+    // In L2-only mode (no L1) all operations are delegated to L2.
 
     fn get_code_verifier(
         &self,
@@ -246,14 +246,13 @@ impl AuthCache for TwoTierAuthCache {
         let key = cv_key(challenge_state);
         let value = code_verifier.to_string();
         Box::pin(async move {
-            // Write to L2 first (source of truth when present)
-            if let Some(l2) = &self.l2 {
-                l2.set_code_verifier(key_tail(&key), &value).await?;
-            }
-
-            // Write to L1
+            // Code verifiers are L1-only when L1 is present: they are
+            // ephemeral, single-use values that do not need to be persisted
+            // to a shared L2 backend.  Fall back to L2 only in L2-only mode.
             if let Some(l1) = &self.l1 {
                 l1.insert(key, L1Entry::CodeVerifier(value)).await;
+            } else if let Some(l2) = &self.l2 {
+                l2.set_code_verifier(key_tail(&key), &value).await?;
             }
 
             Ok(())
@@ -632,11 +631,11 @@ mod tests {
             cache.get_code_verifier("s1").await.unwrap(),
             Some("v1".to_string())
         );
-        // L2 must also have been written to (write-through)
+        // Code verifiers are L1-only when L1 is present; L2 must NOT be written.
         assert_eq!(
             stub.get_code_verifier("s1").await.unwrap(),
-            Some("v1".to_string()),
-            "code verifier must be written to L2 in two-tier mode"
+            None,
+            "code verifier must NOT be written to L2 when L1 is present"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
-use axum::response::IntoResponse;
 use std::fmt;
+
+#[cfg(feature = "server")]
+use axum::response::IntoResponse;
 
 #[cfg(feature = "redis")]
 use redis::RedisError;
@@ -37,6 +39,7 @@ pub enum Error {
     TokenRefreshFailedAuth(String),
 }
 
+#[cfg(feature = "server")]
 impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         match self {
@@ -136,6 +139,7 @@ impl IntoResponse for Error {
     }
 }
 
+#[cfg(feature = "server")]
 impl Error {
     /// Convert HTTP status code and response text to appropriate Error variant
     pub fn from_status_code(status: axum::http::StatusCode, response_text: String) -> Self {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -72,6 +72,19 @@ pub fn build_http_client(custom_ca_cert: Option<&str>) -> Result<Client, Error> 
                     "Failed to read custom CA certificate from '{path}': {e}"
                 ))
             })?;
+
+            // reqwest's rustls backend defers PEM validation to connection
+            // time, so Certificate::from_pem always succeeds regardless of
+            // content.  Validate eagerly here: a valid PEM certificate file
+            // must contain at least one "-----BEGIN CERTIFICATE-----" block.
+            let pem_text = std::str::from_utf8(&pem).unwrap_or("");
+            if !pem_text.contains("-----BEGIN CERTIFICATE-----") {
+                return Err(Error::InvalidResponse(format!(
+                    "Failed to parse custom CA certificate from '{path}': \
+                     no PEM certificate block found"
+                )));
+            }
+
             let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| {
                 Error::InvalidResponse(format!(
                     "Failed to parse custom CA certificate from '{path}': {e}"
@@ -116,8 +129,11 @@ mod tests {
 
     #[test]
     fn test_build_http_client_invalid_pem() {
-        // Write a temp file with invalid PEM content and verify the parse
-        // error is returned correctly.
+        // Write a temp file with plain text content (no PEM headers).
+        // The early validation in build_http_client detects the missing
+        // "-----BEGIN CERTIFICATE-----" block and returns an error before
+        // handing the bytes to reqwest (whose rustls backend would otherwise
+        // defer validation to connection time and succeed here).
         use std::io::Write;
         let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
         tmp.write_all(b"not a valid pem certificate")

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "server")]
 pub mod configuration;
 pub mod jwt_decoder;
+
+#[cfg(feature = "server")]
 pub mod layer;
 pub mod oidc;
 
@@ -10,14 +13,14 @@ pub use oidc::OidcClaims;
 // ── Re-exports from jwt_decoder ───────────────────────────────────────────────
 
 pub use jwt_decoder::{
-    Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode_jwt,
-    decode_jwt_unverified,
+    decode_jwt, decode_jwt_unverified, Algorithm, DecodingKey, EncodingKey, Header, TokenData,
+    Validation,
 };
 
 // ── Re-exports from configuration ─────────────────────────────────────────────
-
+#[cfg(feature = "server")]
 pub use configuration::{Jwk, Jwks, JwtConfiguration, JwtConfigurationBuilder};
 
 // ── Re-exports from layer ─────────────────────────────────────────────────────
-
+#[cfg(feature = "server")]
 pub use layer::{JwtLayer, JwtMiddleware};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,17 @@
 //!
 //! ### Top-level (default)
 //!
+//! - `server` *(default)* – Bundles Axum, axum-extra, PKCE, `tower`, `tracing`, and `tokio/full`.
+//!   Required for running as an HTTP server. Omit when targeting WASM.
 //! - `authentication` *(default)* – OAuth2/OIDC middleware, session management, cache trait,
 //!   builder, router, extractors, and logout handlers.  Implied by every cache/backend feature.
 //! - `jwt` *(default)* – JWT validation and inspection utilities.
+//!
+//! ### reqwest TLS backends (exactly one should be enabled)
+//!
+//! - `reqwest-rustls-tls` *(default)* – rustls TLS for reqwest (recommended)
+//! - `reqwest-native-tls` – system native-tls for reqwest
+//! - `reqwest-native-tls-vendored` – vendored native-tls for reqwest
 //!
 //! ### Cache backends (each implies `authentication`)
 //!
@@ -131,11 +139,18 @@
 //! - `sql-cache-sqlite` – SQLite backend via sqlx
 //! - `sql-cache-all` – all three SQL backends at once (useful for testing)
 //!
+//! ### WASM target
+//!
+//! - `wasm` – JS-backed random source (`getrandom/js`) + `jwt`. Use instead of `default`
+//!   when targeting `wasm32-unknown-unknown`. Do not combine with `server`.
+//!
 //! ## Examples
 //!
 //! See the `examples` directory for a complete working examples.
 
 pub mod errors;
+
+#[cfg(feature = "server")]
 pub mod http_client;
 
 // ── authentication feature ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary by Sourcery

Make server-side Axum integration optional behind a new `server` feature, introduce explicit TLS and WASM feature flags, and adjust caching and error/JWT APIs to support non-server and WASM use cases while bumping the crate to v0.6.0.

New Features:
- Add a `server` feature that gates Axum and other server-side dependencies while remaining part of the default feature set.
- Add a `wasm` feature to support `wasm32-unknown-unknown` targets with JS-backed randomness and JWT-only usage without server components.
- Introduce explicit reqwest TLS backend features (`reqwest-rustls-tls`, `reqwest-native-tls`, `reqwest-native-tls-vendored`) with rustls as the default.
- Add early validation of custom CA PEM files in the HTTP client to fail fast on invalid certificate content.

Bug Fixes:
- Ensure PKCE code verifiers are stored only in the L1 Moka cache when present, avoiding unnecessary writes to L2 backends and clarifying behavior in tests.

Enhancements:
- Mark Axum and related ecosystem dependencies as optional and tie them to feature flags to better support library-only and WASM consumers.
- Gate HTTP client, JWT configuration/layer modules, and error-to-HTTP response conversion behind the `server` feature to avoid pulling in Axum on non-server builds.
- Refine two-tier cache semantics and documentation for PKCE code verifiers, clarifying L1-only vs L2 behavior.
- Reformat and expand feature documentation across docs, README, quick reference, and crate-level docs to describe the new feature layout and usage patterns.
- Update the devcontainer base image to the newer Debian Trixie Rust devcontainer.

Build:
- Adjust Cargo features and optional dependencies so that server-related crates and various utilities are only compiled when their corresponding features are enabled, and update the default and `full` feature sets accordingly.

Documentation:
- Update all user-facing documentation (README, DOCUMENTATION, QUICK_REFERENCE, crate docs, changelog) to reflect version 0.6.0, the new feature flags, WASM usage, and updated examples.

Tests:
- Extend tests for the HTTP client to verify early failure on invalid PEM CA files and adjust cache tests to assert the new L1-only PKCE behavior.