### PR TITLE
Refactor feature gates, imports, and TLS handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ default = ["server", "authentication", "jwt", "moka-cache", "reqwest-rustls-tls"
 
 server = ["axum", "axum-extra", "rand", "chrono", "pkce-std", "time", "uuid", "http", "tower", "tracing", "tokio/full"]
 
-authentication = ["dep:html-escape"]
+authentication = ["server", "dep:html-escape"]
 
 # ── reqwest TLS backends ──────────────────────────────────────────────────────
 # Exactly one should be enabled. `reqwest-rustls-tls` is the default.
@@ -99,5 +99,6 @@ sql-cache-all = ["sql-cache-postgres", "sql-cache-mysql", "sql-cache-sqlite"]
 # wasm32-unknown-unknown.
 wasm = ["getrandom/js", "jwt"]
 
-# Convenience feature that enables every feature in the crate.
-full = ["authentication", "jwt", "moka-cache", "redis", "redis-native-tls", "redis-rustls", "sql-cache-all", "reqwest-rustls-tls"]
+# Convenience feature that enables all compatible production features in the crate.
+# Rustls is selected for Redis because `redis-native-tls` and `redis-rustls` are mutually exclusive.
+full = ["server", "authentication", "jwt", "moka-cache", "redis", "redis-rustls", "sql-cache-all", "reqwest-rustls-tls"]

--- a/src/authentication/logout/handle_default_logout.rs
+++ b/src/authentication/logout/handle_default_logout.rs
@@ -1,9 +1,9 @@
 use crate::{
-    authentication::{cache::AuthCache, LogoutHandler, OAuthConfiguration, SESSION_KEY},
+    authentication::{LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache},
     errors::Error,
 };
 use axum::response::{Html, IntoResponse, Response};
-use axum_extra::extract::{cookie::Cookie, PrivateCookieJar};
+use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
 use futures_util::future::BoxFuture;
 use http::request::Parts;
 use std::sync::Arc;

--- a/src/authentication/logout/handle_oidc_logout.rs
+++ b/src/authentication/logout/handle_oidc_logout.rs
@@ -1,12 +1,12 @@
 use axum::response::{Html, IntoResponse, Redirect, Response};
-use axum_extra::extract::{cookie::Cookie, PrivateCookieJar};
+use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
 use futures_util::future::BoxFuture;
 use http::request::Parts;
 use std::sync::Arc;
 use urlencoding::encode;
 
 use crate::{
-    authentication::{cache::AuthCache, LogoutHandler, OAuthConfiguration, SESSION_KEY},
+    authentication::{LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache},
     errors::Error,
 };
 

--- a/src/authentication/router/handle_default.rs
+++ b/src/authentication/router/handle_default.rs
@@ -1,12 +1,12 @@
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::{
-    cookie::{Cookie, Key},
     PrivateCookieJar,
+    cookie::{Cookie, Key},
 };
 use futures_util::future::BoxFuture;
 use time::Duration;
 
-use crate::authentication::{cache::AuthCache, OAuthConfiguration, SESSION_KEY};
+use crate::authentication::{OAuthConfiguration, SESSION_KEY, cache::AuthCache};
 
 use std::sync::Arc;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use axum::response::IntoResponse;
 #[cfg(feature = "redis")]
 use redis::RedisError;
 
+#[cfg(feature = "server")]
 #[derive(Debug)]
 pub enum Error {
     MissingCodeVerifier,
@@ -37,6 +38,20 @@ pub enum Error {
     CacheAccessError(String),
     SessionUpdateFailed(String),
     TokenRefreshFailedAuth(String),
+}
+
+#[cfg(not(feature = "server"))]
+#[derive(Debug)]
+pub enum Error {
+    MissingCodeVerifier,
+    MissingPatameter(String),
+    NotValidUri(String),
+    Request(reqwest::Error),
+    InvalidCodeResponse(serde_html_form::de::Error),
+    InvalidTokenResponse(serde_json::Error),
+    InvalidResponse(String),
+    CacheError(String),
+    TokenRefreshFailed(String),
 }
 
 #[cfg(feature = "server")]
@@ -159,6 +174,7 @@ impl Error {
     }
 }
 
+#[cfg(feature = "server")]
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -188,6 +204,23 @@ impl fmt::Display for Error {
             Error::CacheAccessError(m) => write!(f, "Cache error: {m}"),
             Error::SessionUpdateFailed(m) => write!(f, "Failed to update session in cache: {m}"),
             Error::TokenRefreshFailedAuth(m) => write!(f, "Token expired and refresh failed: {m}"),
+        }
+    }
+}
+
+#[cfg(not(feature = "server"))]
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::MissingCodeVerifier => write!(f, "Missing code verifier"),
+            Error::MissingPatameter(p) => write!(f, "Missing parameter: {p}"),
+            Error::NotValidUri(u) => write!(f, "Not a valid URI: {u}"),
+            Error::Request(e) => write!(f, "Reqwest error: {e}"),
+            Error::InvalidCodeResponse(e) => write!(f, "Invalid code response: {e}"),
+            Error::InvalidTokenResponse(e) => write!(f, "Invalid token response: {e}"),
+            Error::InvalidResponse(r) => write!(f, "Invalid response: {r}"),
+            Error::CacheError(e) => write!(f, "Cache error: {e}"),
+            Error::TokenRefreshFailed(e) => write!(f, "Token refresh failed: {e}"),
         }
     }
 }

--- a/src/extractors/shared.rs
+++ b/src/extractors/shared.rs
@@ -1,4 +1,4 @@
-use axum::http::{request::Parts, StatusCode};
+use axum::http::{StatusCode, request::Parts};
 use axum_extra::extract::PrivateCookieJar;
 use chrono::Local;
 use reqwest::Client;
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use crate::{
     authentication::{
-        cache::AuthCache, calculate_token_expiration, session::AuthSession, OAuthConfiguration,
-        SESSION_KEY,
+        OAuthConfiguration, SESSION_KEY, cache::AuthCache, calculate_token_expiration,
+        session::AuthSession,
     },
     errors::Error,
 };

--- a/src/extractors/token_extractors.rs
+++ b/src/extractors/token_extractors.rs
@@ -10,7 +10,7 @@ use std::{ops::Deref, sync::Arc};
 
 use super::shared::extract_and_refresh_session;
 use crate::{
-    authentication::{cache::AuthCache, OAuthConfiguration, SESSION_KEY},
+    authentication::{OAuthConfiguration, SESSION_KEY, cache::AuthCache},
     errors::Error,
 };
 

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -8,16 +8,17 @@
 //!
 //! # Custom CA certificates
 //!
-//! When a path is supplied the PEM file is read from disk, parsed as an X.509
-//! certificate, and added to the client's trust store via
-//! [`reqwest::ClientBuilder::add_root_certificate`].  [`use_rustls_tls()`] is
-//! always set when a custom certificate is provided to guarantee a consistent
-//! TLS backend across all call sites.
+//! When a path is supplied and a reqwest TLS feature is enabled, the PEM file
+//! is read from disk, parsed as an X.509 certificate, and added to the client's
+//! trust store via [`reqwest::ClientBuilder::add_root_certificate`].  When the
+//! `reqwest-rustls-tls` feature is enabled, [`use_rustls_tls()`] is set to
+//! guarantee a consistent TLS backend across all call sites.
 //!
 //! # Errors
 //!
 //! [`build_http_client`] returns [`Error::InvalidResponse`] (rather than
 //! panicking) when:
+//! - A custom CA certificate is configured without a reqwest TLS feature.
 //! - The certificate file cannot be read from the given path.
 //! - The file contents cannot be parsed as a PEM-encoded X.509 certificate.
 //! - The [`reqwest::ClientBuilder`] fails to produce a client (this is
@@ -46,9 +47,9 @@ use crate::errors::Error;
 ///
 /// # Errors
 ///
-/// Returns [`Error::InvalidResponse`] if the certificate file cannot be read
-/// or parsed, or if the underlying [`reqwest::ClientBuilder::build`] call
-/// fails.
+/// Returns [`Error::InvalidResponse`] if a custom CA certificate is configured
+/// without a reqwest TLS feature, if the certificate file cannot be read or
+/// parsed, or if the underlying [`reqwest::ClientBuilder::build`] call fails.
 ///
 /// # Examples
 ///
@@ -67,32 +68,24 @@ use crate::errors::Error;
 pub fn build_http_client(custom_ca_cert: Option<&str>) -> Result<Client, Error> {
     let builder = match custom_ca_cert {
         Some(path) => {
-            let pem = std::fs::read(path).map_err(|e| {
-                Error::InvalidResponse(format!(
-                    "Failed to read custom CA certificate from '{path}': {e}"
-                ))
-            })?;
-
-            // reqwest's rustls backend defers PEM validation to connection
-            // time, so Certificate::from_pem always succeeds regardless of
-            // content.  Validate eagerly here: a valid PEM certificate file
-            // must contain at least one "-----BEGIN CERTIFICATE-----" block.
-            let pem_text = std::str::from_utf8(&pem).unwrap_or("");
-            if !pem_text.contains("-----BEGIN CERTIFICATE-----") {
+            #[cfg(not(any(
+                feature = "reqwest-rustls-tls",
+                feature = "reqwest-native-tls",
+                feature = "reqwest-native-tls-vendored"
+            )))]
+            {
                 return Err(Error::InvalidResponse(format!(
-                    "Failed to parse custom CA certificate from '{path}': \
-                     no PEM certificate block found"
+                    "Custom CA certificate '{path}' requires one reqwest TLS feature: \
+                     `reqwest-rustls-tls`, `reqwest-native-tls`, or `reqwest-native-tls-vendored`"
                 )));
             }
 
-            let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| {
-                Error::InvalidResponse(format!(
-                    "Failed to parse custom CA certificate from '{path}': {e}"
-                ))
-            })?;
-            reqwest::ClientBuilder::new()
-                .add_root_certificate(cert)
-                .use_rustls_tls()
+            #[cfg(any(
+                feature = "reqwest-rustls-tls",
+                feature = "reqwest-native-tls",
+                feature = "reqwest-native-tls-vendored"
+            ))]
+            build_http_client_with_custom_ca(path)?
         }
         None => reqwest::ClientBuilder::new(),
     };
@@ -100,6 +93,44 @@ pub fn build_http_client(custom_ca_cert: Option<&str>) -> Result<Client, Error> 
     builder
         .build()
         .map_err(|e| Error::InvalidResponse(format!("Failed to build HTTP client: {e}")))
+}
+
+#[cfg(any(
+    feature = "reqwest-rustls-tls",
+    feature = "reqwest-native-tls",
+    feature = "reqwest-native-tls-vendored"
+))]
+fn build_http_client_with_custom_ca(path: &str) -> Result<reqwest::ClientBuilder, Error> {
+    let pem = std::fs::read(path).map_err(|e| {
+        Error::InvalidResponse(format!(
+            "Failed to read custom CA certificate from '{path}': {e}"
+        ))
+    })?;
+
+    // reqwest's rustls backend defers PEM validation to connection
+    // time, so Certificate::from_pem always succeeds regardless of
+    // content.  Validate eagerly here: a valid PEM certificate file
+    // must contain at least one "-----BEGIN CERTIFICATE-----" block.
+    let pem_text = std::str::from_utf8(&pem).unwrap_or("");
+    if !pem_text.contains("-----BEGIN CERTIFICATE-----") {
+        return Err(Error::InvalidResponse(format!(
+            "Failed to parse custom CA certificate from '{path}': \
+             no PEM certificate block found"
+        )));
+    }
+
+    let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| {
+        Error::InvalidResponse(format!(
+            "Failed to parse custom CA certificate from '{path}': {e}"
+        ))
+    })?;
+
+    let builder = reqwest::ClientBuilder::new().add_root_certificate(cert);
+
+    #[cfg(feature = "reqwest-rustls-tls")]
+    let builder = builder.use_rustls_tls();
+
+    Ok(builder)
 }
 
 #[cfg(test)]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -13,8 +13,8 @@ pub use oidc::OidcClaims;
 // ── Re-exports from jwt_decoder ───────────────────────────────────────────────
 
 pub use jwt_decoder::{
-    decode_jwt, decode_jwt_unverified, Algorithm, DecodingKey, EncodingKey, Header, TokenData,
-    Validation,
+    Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode_jwt,
+    decode_jwt_unverified,
 };
 
 // ── Re-exports from configuration ─────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,11 @@
 //!
 //! See the `examples` directory for a complete working examples.
 
+#[cfg(all(feature = "server", feature = "wasm"))]
+compile_error!(
+    "features `server` and `wasm` are mutually exclusive; use `server` for native Axum apps or `wasm` for wasm32 targets"
+);
+
 pub mod errors;
 
 #[cfg(feature = "server")]

--- a/tests/sql_cache_sqlite.rs
+++ b/tests/sql_cache_sqlite.rs
@@ -119,11 +119,13 @@ async fn invalidate_code_verifier_removes_entry() {
         .expect("set_code_verifier failed");
 
     // Confirm it exists.
-    assert!(cache
-        .get_code_verifier("state-del")
-        .await
-        .unwrap()
-        .is_some());
+    assert!(
+        cache
+            .get_code_verifier("state-del")
+            .await
+            .unwrap()
+            .is_some()
+    );
 
     cache
         .invalidate_code_verifier("state-del")
@@ -517,7 +519,7 @@ async fn new_returns_error_for_unrecognised_scheme() {
 
 #[tokio::test]
 async fn two_tier_cache_with_sqlite_l2() {
-    use axum_oidc_client::cache::{config::TwoTierCacheConfig, TwoTierAuthCache};
+    use axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig};
 
     let sql_cache = Arc::new(make_cache().await);
 
@@ -578,7 +580,7 @@ async fn two_tier_cache_with_sqlite_l2() {
 
 #[tokio::test]
 async fn two_tier_code_verifier_stored_only_in_l1() {
-    use axum_oidc_client::cache::{config::TwoTierCacheConfig, TwoTierAuthCache};
+    use axum_oidc_client::cache::{TwoTierAuthCache, config::TwoTierCacheConfig};
 
     let sql_cache = Arc::new(make_cache().await);
     let sql_cache_ref = Arc::clone(&sql_cache);


### PR DESCRIPTION
## Summary by Sourcery

Refine feature gating, TLS configuration, and platform feature combinations while tightening error handling and crate feature presets.

Bug Fixes:
- Return a clear error when a custom CA certificate is configured without enabling a reqwest TLS backend feature.

Enhancements:
- Extract custom CA certificate handling into a helper under appropriate TLS feature gates and only force the rustls backend when the rustls TLS feature is selected.
- Split the Error type and its Display implementation between server and non-server builds to match enabled features and avoid unnecessary dependencies.
- Make the authentication feature depend on the server feature and adjust the full feature to enable only compatible production features with rustls-based Redis TLS.
- Add a compile-time error when incompatible server and wasm features are enabled together.
- Tidy imports, re-export ordering, and test formatting for consistency.

Documentation:
- Clarify documentation around custom CA certificate usage, including required reqwest TLS features and updated error conditions.

Tests:
- Adjust test imports and assertion formatting without changing test behavior.