### PR TITLE
Bump dependencies and update version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-02
+
+### Changed
+
+- Kept `reqwest` and `redis` out of the public API surface so their major-version updates remain internal implementation details.
+- Relaxed dependency requirements to compatible major/minor ranges where practical, so patch-level dependency updates do not require crate releases.
+- Removed the direct `getrandom` dependency from the `wasm` feature; final applications now choose their own wasm random-source backend.
+- Updated dependency versions while preserving existing feature layout and defaults:
+  - `tokio` 1.41 → 1.52
+  - `reqwest` 0.12.22 → 0.13.4
+  - `serde_html_form` 0.2.7 → 0.4.0
+  - `axum-extra` 0.10.0 → 0.12.6
+  - `axum` 0.8.6 → 0.8.9
+  - `serde` 1.0.219 → 1.0.228
+  - `serde_json` 1.0.140 → 1.0.150
+  - `rand` 0.9.1 → 0.10.1
+  - `http` 1.2.0 → 1.4.1
+  - `futures-util` 0.3.31 → 0.3.32
+  - `tower` 0.5.2 → 0.5.3
+  - `uuid` 1.18.1 → 1.23.2
+  - `time` 0.3.44 → 0.3.47
+  - `redis` 1.0.0-rc.3 → 1.2.2
+  - `moka` 0.12.11 → 0.12.15
+  - `chrono` 0.4.42 → 0.4.44
+  - `sqlx` 0.8 → 0.9
+  - `jsonwebtoken` 10.3 → 10.4
+
 ## [0.6.0] - 2026-05-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"
@@ -9,43 +9,40 @@ homepage = "https://github.com/RedSoftwareSystems/axum-oidc-client"
 repository = "https://github.com/RedSoftwareSystems/axum-oidc-client"
 
 [dependencies]
-tokio = { version = "1.41" }
-reqwest = { version = "0.12.22", default-features = false, features = ["json"] }
-pkce-std = { version = "0.2.1", optional = true }
-serde_html_form = "0.2.7"
-axum-extra = { version = "0.10.0", optional = true, features = [
+tokio = { version = "1.52" }
+reqwest = { version = "0.13", default-features = false, features = ["json", "form"] }
+pkce-std = { version = "0.2", optional = true }
+serde_html_form = "0.4"
+axum-extra = { version = "0.12", optional = true, features = [
     "cookie",
     "cookie-private",
     "cookie-signed",
 ] }
-axum = { version = "0.8.6", optional = true, features = ["macros"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = { version = "1.0.140" }
-rand = { version = "0.9.1", optional = true}
-http = { version = "1.2.0", optional = true }
-futures-util = { version = "0.3.31" }
-tower = { version = "0.5.2", optional = true }
+axum = { version = "0.8", optional = true, features = ["macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+rand = { version = "0.10", optional = true }
+http = { version = "1", optional = true }
+futures-util = { version = "0.3" }
+tower = { version = "0.5", optional = true }
 
-urlencoding = "2.1"
-uuid = { version = "1.18.1", optional = true, features = ["v4"] }
-time = { version = "0.3.44", optional = true}
-redis = { version = "1.0.0-rc.3", optional = true, features = ["tokio-comp", "connection-manager"]}
-moka = { version = "0.12.11", optional = true, features = ["future"]}
-chrono = {version = "0.4.42", optional = true, features = ["serde"]}
+urlencoding = "2"
+uuid = { version = "1", optional = true, features = ["v4"] }
+time = { version = "0.3", optional = true }
+redis = { version = "1.2", optional = true, features = ["tokio-comp", "connection-manager"] }
+moka = { version = "0.12", optional = true, features = ["future"] }
+chrono = { version = "0.4", optional = true, features = ["serde"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-tracing = { version = "0.1", optional = true}
+tracing = { version = "0.1", optional = true }
 html-escape = { version = "0.2", optional = true }
 
 # sqlx is pulled in only when at least one sql-cache-* feature is enabled.
 # The runtime is always tokio; the database driver is selected per feature.
-sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "chrono"] }
+sqlx = { version = "0.9", optional = true, features = ["runtime-tokio", "chrono"] }
 
 # jsonwebtoken and base64 are pulled in only when the `jwt` feature is enabled.
-jsonwebtoken = { version = "10.3", optional = true, features = ["rust_crypto"] }
+jsonwebtoken = { version = "10", optional = true, features = ["rust_crypto"] }
 base64 = { version = "0.22", optional = true }
-
-# getrandom is pulled in only when the `wasm` feature is enabled.
-getrandom = { version = "0.2", optional = true }
 
 [dev-dependencies]
 mockito = "1"
@@ -69,7 +66,7 @@ authentication = ["server", "dep:html-escape"]
 
 # ── reqwest TLS backends ──────────────────────────────────────────────────────
 # Exactly one should be enabled. `reqwest-rustls-tls` is the default.
-reqwest-rustls-tls          = ["reqwest/rustls-tls"]
+reqwest-rustls-tls          = ["reqwest/rustls"]
 reqwest-native-tls          = ["reqwest/native-tls"]
 reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
 
@@ -94,10 +91,9 @@ sql-cache-sqlite   = ["authentication", "dep:sqlx", "sqlx?/sqlite"]
 sql-cache-all = ["sql-cache-postgres", "sql-cache-mysql", "sql-cache-sqlite"]
 
 # ── WASM support ─────────────────────────────────────────────────────────────
-# Enables the JS-backed random source required by getrandom on wasm32 targets,
-# plus JWT support.  Select this feature instead of `default` when targeting
-# wasm32-unknown-unknown.
-wasm = ["getrandom/js", "jwt"]
+# Enables JWT support without server-side Axum dependencies. Random-source
+# backend selection for wasm32 targets is left to the final application.
+wasm = ["jwt"]
 
 # Convenience feature that enables all compatible production features in the crate.
 # Rustls is selected for Redis because `redis-native-tls` and `redis-rustls` are mutually exclusive.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# axum-oidc-client API Documentation (v0.6.0)
+# axum-oidc-client API Documentation (v0.6.1)
 
 Complete API documentation and usage guide for the axum-oidc-client library.
 
@@ -59,7 +59,7 @@ Complete API documentation and usage guide for the axum-oidc-client library.
 
 | Flag | Default | Description |
 |---|---|---|
-| `wasm` | ❌ | Enables JS-backed random source (`getrandom/js`) and JWT support. Use instead of `default` when targeting `wasm32-unknown-unknown`. The `server` feature must **not** be enabled alongside `wasm`. |
+| `wasm` | ❌ | Enables JWT support without server-side Axum dependencies. Use instead of `default` when targeting `wasm32-unknown-unknown`. Configure any required `getrandom` backend in your final application. The `server` feature must **not** be enabled alongside `wasm`. |
 
 ## Core Concepts
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -402,9 +402,9 @@ Requires one of the `sql-cache-*` feature flags. An alternative L2 backend to Re
 
 ```toml
 # Choose one (or use sql-cache-all for testing):
-axum-oidc-client = { version = "0.4.0", features = ["sql-cache-sqlite"] }
-axum-oidc-client = { version = "0.4.0", features = ["sql-cache-postgres"] }
-axum-oidc-client = { version = "0.4.0", features = ["sql-cache-mysql"] }
+axum-oidc-client = { version = "0.6", features = ["sql-cache-sqlite"] }
+axum-oidc-client = { version = "0.6", features = ["sql-cache-postgres"] }
+axum-oidc-client = { version = "0.6", features = ["sql-cache-mysql"] }
 ```
 
 ```rust
@@ -912,7 +912,7 @@ async fn test_refresh(session: AuthSession) -> String {
 | `sql-cache-postgres` | ❌ no | PostgreSQL L2 cache backend (via SQLx) |
 | `sql-cache-mysql` | ❌ no | MySQL/MariaDB L2 cache backend (via SQLx) |
 | `sql-cache-all` | ❌ no | All SQL backends (useful for testing) |
-| `wasm` | ❌ no | JS-backed random source + JWT. Use instead of `default` for `wasm32-unknown-unknown` targets. |
+| `wasm` | ❌ no | JWT support without server-side Axum dependencies. Use instead of `default` for `wasm32-unknown-unknown` targets; configure any required `getrandom` backend in your final application. |
 
 ```toml
 # Default features (server + authentication + jwt + moka-cache + reqwest-rustls-tls)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.5"
+axum-oidc-client = "0.6"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -56,7 +56,7 @@ tokio = { version = "1", features = ["full"] }
 
 #### WASM
 
-- `wasm` – JS-backed random source + JWT. Use instead of `default` when targeting `wasm32-unknown-unknown`.
+- `wasm` – JWT support without server-side Axum dependencies. Use instead of `default` when targeting `wasm32-unknown-unknown`. Configure any required `getrandom` backend in your final application.
 
 ```toml
 [dependencies]

--- a/examples/www-server/Cargo.toml
+++ b/examples/www-server/Cargo.toml
@@ -61,8 +61,8 @@ cache-l1-sqlite = ["cache-l1", "cache-sqlite"]
 default = ["cache-l1"]
 
 [dependencies]
-axum = "0.8.4"
-axum-extra = { version = "0.10.0", features = [
+axum = "0.8"
+axum-extra = { version = "0.12", features = [
     "cookie",
     "cookie-private",
     "cookie-signed",
@@ -78,9 +78,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # Cache features are activated transitively through this crate's own features
 # (see the [features] section above); do NOT hard-code them here.
 axum-oidc-client = { path = "../.." }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
-clap = { version = "4.5.51", features = ["derive", "env"] }
-clap_derive = "4.5.49"
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "stream"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_derive = "4"
 dotenv = "0.15"
-base64 = "0.21"
-jsonwebtoken = "10.3.0"
+base64 = "0.22"
+jsonwebtoken = "10"

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -314,7 +314,7 @@ impl OAuthConfigurationBuilder {
             .get(&discovery_url)
             .send()
             .await
-            .map_err(Error::Request)?;
+            .map_err(Error::from_request_error)?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/src/authentication/redis/mod.rs
+++ b/src/authentication/redis/mod.rs
@@ -10,8 +10,13 @@ compile_error!(
     "feature \"redis-native-tls\" and feature \"redis-rustls\" cannot be enabled at the same time"
 );
 const CODE_TTL_SEC: u64 = 60;
+
+fn cache_error(err: impl std::fmt::Display) -> Error {
+    Error::CacheError(err.to_string())
+}
+
 pub struct AuthCache {
-    pub client: Client,
+    client: Client,
     pub ttl_sec: u64,
 }
 
@@ -34,8 +39,8 @@ impl auth_cache::AuthCache for AuthCache {
     ) -> BoxFuture<'_, Result<Option<String>, Error>> {
         let code_id = format!("code_verifier.{challenge_state}");
         Box::pin(async move {
-            let mut con = self.con().await?;
-            let cache_result = con.get(&code_id).await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            let cache_result = con.get(&code_id).await.map_err(cache_error)?;
             Ok(cache_result)
         })
     }
@@ -48,8 +53,10 @@ impl auth_cache::AuthCache for AuthCache {
         let code_id = format!("code_verifier.{challenge_state}");
         let code_verifier = code_verifier.to_string();
         Box::pin(async move {
-            let mut con = self.con().await?;
-            con.set_ex(&code_id, code_verifier, CODE_TTL_SEC).await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            con.set_ex(&code_id, code_verifier, CODE_TTL_SEC)
+                .await
+                .map_err(cache_error)?;
 
             Ok(())
         })
@@ -58,8 +65,8 @@ impl auth_cache::AuthCache for AuthCache {
     fn invalidate_code_verifier(&self, challenge_state: &str) -> BoxFuture<'_, Result<(), Error>> {
         let code_id = format!("code_verifier.{challenge_state}");
         Box::pin(async move {
-            let mut con = self.con().await?;
-            con.del(&code_id).await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            con.del(&code_id).await.map_err(cache_error)?;
             Ok(())
         })
     }
@@ -70,8 +77,8 @@ impl auth_cache::AuthCache for AuthCache {
     ) -> BoxFuture<'_, Result<Option<AuthSession>, Error>> {
         let session_id = format!("session.{session_id}");
         Box::pin(async move {
-            let mut con = self.con().await?;
-            let cache_result = con.get(&session_id).await?.map(|v| {
+            let mut con = self.con().await.map_err(cache_error)?;
+            let cache_result = con.get(&session_id).await.map_err(cache_error)?.map(|v| {
                 serde_json::from_str::<AuthSession>(&v)
                     .map_err(|e| Error::CacheError(e.to_string()))
             });
@@ -93,9 +100,11 @@ impl auth_cache::AuthCache for AuthCache {
     ) -> BoxFuture<'_, Result<(), Error>> {
         let session_id = format!("session.{session_id}");
         Box::pin(async move {
-            let mut con = self.con().await?;
-            con.set_ex(&session_id, serde_json::to_string(&session)?, self.ttl_sec)
-                .await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            let session = serde_json::to_string(&session).map_err(cache_error)?;
+            con.set_ex(&session_id, session, self.ttl_sec)
+                .await
+                .map_err(cache_error)?;
 
             Ok(())
         })
@@ -104,8 +113,8 @@ impl auth_cache::AuthCache for AuthCache {
     fn invalidate_auth_session(&self, session_id: &str) -> BoxFuture<'_, Result<(), Error>> {
         let session_id = format!("session.{session_id}");
         Box::pin(async move {
-            let mut con = self.con().await?;
-            con.del(&session_id).await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            con.del(&session_id).await.map_err(cache_error)?;
             Ok(())
         })
     }
@@ -113,8 +122,8 @@ impl auth_cache::AuthCache for AuthCache {
     fn extend_auth_session(&self, session_id: &str, ttl: i64) -> BoxFuture<'_, Result<(), Error>> {
         let session_id = session_id.to_string();
         Box::pin(async move {
-            let mut con = self.con().await?;
-            con.expire(&session_id, ttl).await?;
+            let mut con = self.con().await.map_err(cache_error)?;
+            con.expire(&session_id, ttl).await.map_err(cache_error)?;
             Ok(())
         })
     }

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -44,7 +44,10 @@ async fn get_auth_tokens(
 ) -> Result<(AccessTokenResponse, Option<String>), Error> {
     let querystring = uri.query();
     let query = querystring
-        .map(|qs| serde_html_form::from_str::<CodeExchange>(qs).map_err(Error::InvalidCodeResponse))
+        .map(|qs| {
+            serde_html_form::from_str::<CodeExchange>(qs)
+                .map_err(|e| Error::InvalidCodeResponse(e.to_string()))
+        })
         .ok_or(Error::MissingPatameter("code".to_owned()))
         .flatten()?;
 
@@ -100,16 +103,20 @@ async fn get_auth_tokens(
             },
         )
         .send()
-        .await?;
+        .await
+        .map_err(Error::from_request_error)?;
 
     match res.status() {
         StatusCode::OK => {
-            let auth_session = res.json::<AccessTokenResponse>().await?;
+            let auth_session = res
+                .json::<AccessTokenResponse>()
+                .await
+                .map_err(Error::from_request_error)?;
 
             Ok((auth_session, post_login_redirect))
         }
         status => {
-            let err = res.text().await?;
+            let err = res.text().await.map_err(Error::from_request_error)?;
             Err(Error::from_status_code(status, err))
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,18 +3,15 @@ use std::fmt;
 #[cfg(feature = "server")]
 use axum::response::IntoResponse;
 
-#[cfg(feature = "redis")]
-use redis::RedisError;
-
 #[cfg(feature = "server")]
 #[derive(Debug)]
 pub enum Error {
     MissingCodeVerifier,
     MissingPatameter(String),
     NotValidUri(String),
-    Request(reqwest::Error),
-    InvalidCodeResponse(serde_html_form::de::Error),
-    InvalidTokenResponse(serde_json::Error),
+    Request(String),
+    InvalidCodeResponse(String),
+    InvalidTokenResponse(String),
     InvalidResponse(String),
     CacheError(String),
     TokenRefreshFailed(String),
@@ -46,9 +43,9 @@ pub enum Error {
     MissingCodeVerifier,
     MissingPatameter(String),
     NotValidUri(String),
-    Request(reqwest::Error),
-    InvalidCodeResponse(serde_html_form::de::Error),
-    InvalidTokenResponse(serde_json::Error),
+    Request(String),
+    InvalidCodeResponse(String),
+    InvalidTokenResponse(String),
     InvalidResponse(String),
     CacheError(String),
     TokenRefreshFailed(String),
@@ -225,38 +222,11 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Request(e) => Some(e),
-            Error::InvalidCodeResponse(e) => Some(e),
-            Error::InvalidTokenResponse(e) => Some(e),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for Error {}
 
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
-        Error::Request(err)
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Error::InvalidTokenResponse(err)
-    }
-}
-
-impl From<serde_html_form::de::Error> for Error {
-    fn from(err: serde_html_form::de::Error) -> Self {
-        Error::InvalidCodeResponse(err)
-    }
-}
-
-#[cfg(feature = "redis")]
-impl From<RedisError> for Error {
-    fn from(err: RedisError) -> Self {
-        Error::CacheError(err.to_string())
+impl Error {
+    #[allow(dead_code)]
+    pub(crate) fn from_request_error(err: reqwest::Error) -> Self {
+        Error::Request(err.to_string())
     }
 }

--- a/src/extractors/shared.rs
+++ b/src/extractors/shared.rs
@@ -56,11 +56,15 @@ pub async fn refresh_tokens(
             },
         )
         .send()
-        .await?;
+        .await
+        .map_err(Error::from_request_error)?;
 
     match res.status() {
         StatusCode::OK => {
-            let refresh_response = res.json::<RefreshTokenResponse>().await?;
+            let refresh_response = res
+                .json::<RefreshTokenResponse>()
+                .await
+                .map_err(Error::from_request_error)?;
             Ok(refresh_response)
         }
         status => {
@@ -82,7 +86,7 @@ pub async fn extract_and_refresh_session(
         .get_auth_session(session_id)
         .await
         .map_err(|err| Error::CacheAccessError(format!("{err:?}")))?
-        .ok_or_else(|| Error::SessionExpired)?;
+        .ok_or(Error::SessionExpired)?;
 
     // Check if the token is expired
     let now = Local::now();
@@ -154,13 +158,13 @@ pub async fn extract_auth_session(parts: &mut Parts) -> Result<AuthSession, Erro
     let headers = parts.headers.clone();
 
     // Check cache
-    let cache = cache.ok_or_else(|| Error::AuthCacheNotConfigured)?;
+    let cache = cache.ok_or(Error::AuthCacheNotConfigured)?;
 
     // Check config
-    let config = config.ok_or_else(|| Error::OAuthConfigNotConfigured)?;
+    let config = config.ok_or(Error::OAuthConfigNotConfigured)?;
 
     // Check client
-    let client = client.ok_or_else(|| Error::HttpClientNotConfigured)?;
+    let client = client.ok_or(Error::HttpClientNotConfigured)?;
 
     // Extract the session ID from the private cookie jar
     let jar = PrivateCookieJar::from_headers(&headers, config.private_cookie_key.clone());
@@ -168,7 +172,7 @@ pub async fn extract_auth_session(parts: &mut Parts) -> Result<AuthSession, Erro
     let session_id = jar
         .get(SESSION_KEY)
         .map(|cookie| cookie.value().to_string())
-        .ok_or_else(|| Error::SessionNotFound)?;
+        .ok_or(Error::SessionNotFound)?;
 
     // Extract and refresh session if needed
     let session = extract_and_refresh_session(&cache, &config, &client, &session_id).await?;

--- a/src/extractors/token_extractors.rs
+++ b/src/extractors/token_extractors.rs
@@ -35,11 +35,11 @@ where
     let headers = parts.headers.clone();
 
     // Check cache, config, and client
-    let cache = cache.ok_or_else(|| Error::AuthCacheNotConfigured)?;
+    let cache = cache.ok_or(Error::AuthCacheNotConfigured)?;
 
-    let config = config.ok_or_else(|| Error::OAuthConfigNotConfigured)?;
+    let config = config.ok_or(Error::OAuthConfigNotConfigured)?;
 
-    let client = client.ok_or_else(|| Error::HttpClientNotConfigured)?;
+    let client = client.ok_or(Error::HttpClientNotConfigured)?;
 
     // Extract the session ID from the private cookie jar
     let jar = PrivateCookieJar::from_headers(&headers, config.private_cookie_key.clone());
@@ -47,7 +47,7 @@ where
     let session_id = jar
         .get(SESSION_KEY)
         .map(|cookie| cookie.value().to_string())
-        .ok_or_else(|| Error::SessionNotFound)?;
+        .ok_or(Error::SessionNotFound)?;
 
     // Use shared logic to extract and refresh session if needed
     let session = extract_and_refresh_session(&cache, &config, &client, &session_id).await?;

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -53,19 +53,8 @@ use crate::errors::Error;
 ///
 /// # Examples
 ///
-/// ```rust,no_run
-/// use axum_oidc_client::http_client::build_http_client;
-///
-/// # fn example() -> Result<(), axum_oidc_client::errors::Error> {
-/// // Default client — trusts the system root store.
-/// let client = build_http_client(None)?;
-///
-/// // Client that also trusts a private CA.
-/// let client = build_http_client(Some("/etc/ssl/my-corp-ca.pem"))?;
-/// # Ok(())
-/// # }
-/// ```
-pub fn build_http_client(custom_ca_cert: Option<&str>) -> Result<Client, Error> {
+/// This is an internal helper used by authentication and JWT discovery flows.
+pub(crate) fn build_http_client(custom_ca_cert: Option<&str>) -> Result<Client, Error> {
     let builder = match custom_ca_cert {
         Some(path) => {
             #[cfg(not(any(

--- a/src/jwt/configuration.rs
+++ b/src/jwt/configuration.rs
@@ -254,7 +254,7 @@ where
                 .get(uri)
                 .send()
                 .await
-                .map_err(Error::Request)?
+                .map_err(Error::from_request_error)?
                 .error_for_status()
                 .map_err(|e| {
                     Error::InvalidResponse(format!("JWKS refresh request to {uri} failed: {e}"))
@@ -407,7 +407,7 @@ impl<C: DeserializeOwned> JwtConfigurationBuilder<C> {
             .get(&discovery_url)
             .send()
             .await
-            .map_err(Error::Request)?
+            .map_err(Error::from_request_error)?
             .error_for_status()
             .map_err(|e| {
                 Error::InvalidResponse(format!(
@@ -443,7 +443,7 @@ impl<C: DeserializeOwned> JwtConfigurationBuilder<C> {
             .get(jwks_uri)
             .send()
             .await
-            .map_err(Error::Request)?
+            .map_err(Error::from_request_error)?
             .error_for_status()
             .map_err(|e| Error::InvalidResponse(format!("JWKS request to {jwks_uri} failed: {e}")))?
             .json()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,9 @@
 //!
 //! ### WASM target
 //!
-//! - `wasm` – JS-backed random source (`getrandom/js`) + `jwt`. Use instead of `default`
-//!   when targeting `wasm32-unknown-unknown`. Do not combine with `server`.
+//! - `wasm` – `jwt` support without server-side Axum dependencies. Use instead of `default`
+//!   when targeting `wasm32-unknown-unknown`. Configure any required `getrandom` backend
+//!   in your final application. Do not combine with `server`.
 //!
 //! ## Examples
 //!
@@ -156,7 +157,7 @@ compile_error!(
 pub mod errors;
 
 #[cfg(feature = "server")]
-pub mod http_client;
+pub(crate) mod http_client;
 
 // ── authentication feature ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary by Sourcery

Bump crate version to 0.6.1 and refresh dependency versions to current compatible releases.

Enhancements:
- Update core and optional dependency versions (Tokio, Axum, reqwest, serde stack, storage/cache libraries, and crypto/util crates) while preserving the existing feature layout and defaults.

Documentation:
- Extend the changelog with a 0.6.1 entry describing the dependency updates.