### PR TITLE
Feature fix/audience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-04
+
+### Added
+
+- **`OAuthConfigurationBuilder::with_audience(&str)`**: sends an optional `audience` query parameter on the authorization request. This is useful for providers such as Auth0 that require an API/resource identifier to mint access tokens for a specific API.
+- **`OAuthConfiguration::audience: Option<String>`**: stores the optional authorization-request audience. `None` preserves previous behavior and omits the parameter.
+
+### Changed
+
+- Authorization endpoint URL generation now includes `audience=<value>` when `OAuthConfiguration::audience` is configured.
+
+### Breaking
+
+- `OAuthConfiguration` gained a public `audience` field. Code that constructs `OAuthConfiguration` directly with a struct literal must add `audience: None` or `audience: Some("...".to_string())`. Builder-based configuration is unaffected.
+
 ## [0.6.1] - 2026-06-02
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-oidc-client"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "OpenID Connect (OIDC) and OAuth2 client middleware for Axum web framework"

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# axum-oidc-client API Documentation (v0.6.1)
+# axum-oidc-client API Documentation (v0.7.0)
 
 Complete API documentation and usage guide for the axum-oidc-client library.
 
@@ -403,6 +403,7 @@ OAuth2/OIDC configuration container.
 - `client_id: String` - OAuth2 client identifier
 - `base_path: String` - Base path for authentication routes (default: "/auth")
 - `client_secret: String` - OAuth2 client secret
+- `audience: Option<String>` - Optional `audience` query parameter sent to the authorization endpoint
 - `redirect_uri: String` - Callback URI
 - `authorization_endpoint: String` - Provider's auth endpoint
 - `token_endpoint: String` - Provider's token endpoint
@@ -460,6 +461,7 @@ Fluent API for building configurations.
 | `with_issuer(url).await?`            | No*      | OIDC auto-discovery: populates `authorization_endpoint`, `token_endpoint`, and `end_session_endpoint` from the provider's discovery document |
 | `with_client_id(id)`                 | Yes      | Set OAuth2 client ID                               |
 | `with_client_secret(secret)`         | Yes      | Set OAuth2 client secret                           |
+| `with_audience(audience)`            | No       | Set optional authorization-request audience/resource identifier |
 | `with_redirect_uri(uri)`             | Yes      | Set callback URI                                   |
 | `with_authorization_endpoint(url)`   | Yes*     | Set auth endpoint (not required when using `with_issuer`) |
 | `with_token_endpoint(url)`           | Yes*     | Set token endpoint (not required when using `with_issuer`) |
@@ -501,6 +503,7 @@ let config = OAuthConfigurationBuilder::default()
 let config = OAuthConfigurationBuilder::default()
     .with_client_id("client-id")
     .with_client_secret("client-secret")
+    .with_audience("https://api.example.com") // Optional: request an API/resource audience
     .with_redirect_uri("http://localhost:8080/auth/callback")
     .with_authorization_endpoint("https://provider.com/oauth/authorize")
     .with_token_endpoint("https://provider.com/oauth/token")
@@ -509,6 +512,8 @@ let config = OAuthConfigurationBuilder::default()
     .with_base_path("/auth")  // Optional, default is "/auth"
     .build()?;
 ```
+
+`with_audience(...)` affects the OAuth/OIDC authorization redirect by adding an `audience` query parameter. It is separate from `JwtConfigurationBuilder::with_audience(...)`, which validates the `aud` claim on incoming bearer tokens.
 
 **Custom Base Path Example:**
 
@@ -1168,6 +1173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = OAuthConfigurationBuilder::default()
         .with_client_id(std::env::var("OAUTH_CLIENT_ID")?)
         .with_client_secret(std::env::var("OAUTH_CLIENT_SECRET")?)
+        .with_audience("https://api.example.com") // Optional: request an API/resource audience
         .with_redirect_uri("http://localhost:8080/auth/callback")
         .with_authorization_endpoint("https://provider.com/authorize")
         .with_token_endpoint("https://provider.com/token")
@@ -1337,7 +1343,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = OAuthConfigurationBuilder::default()
+    let mut builder = OAuthConfigurationBuilder::default()
         .with_client_id(&env::var("OAUTH_CLIENT_ID")?)
         .with_client_secret(&env::var("OAUTH_CLIENT_SECRET")?)
         .with_redirect_uri(&env::var("OAUTH_REDIRECT_URI")?)
@@ -1346,8 +1352,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_private_cookie_key(&env::var("PRIVATE_COOKIE_KEY")?)
         .with_session_max_age(
             env::var("SESSION_MAX_AGE")?.parse().unwrap_or(30)
-        )
-        .build()?;
+        );
+
+    if let Ok(audience) = env::var("OAUTH_AUDIENCE") {
+        builder = builder.with_audience(&audience);
+    }
+
+    let config = builder.build()?;
 
     let cache: Arc<dyn axum_oidc_client::auth_cache::AuthCache + Send + Sync> = Arc::new(
         axum_oidc_client::cache::TwoTierAuthCache::new(

--- a/PROVIDER_EXAMPLES.md
+++ b/PROVIDER_EXAMPLES.md
@@ -445,6 +445,7 @@ let config = OAuthConfigurationBuilder::default()
     ))
     .with_client_id("your-auth0-client-id")
     .with_client_secret("your-auth0-client-secret")
+    .with_audience("https://api.example.com") // Optional: Auth0 API Identifier
     .with_redirect_uri("http://localhost:8080/auth/callback")
     .with_post_logout_redirect_uri("http://localhost:8080")
     .with_private_cookie_key("your-secret-key-at-least-32-bytes")
@@ -479,6 +480,7 @@ OAUTH_TOKEN_ENDPOINT=https://${AUTH0_DOMAIN}/oauth/token
 OAUTH_END_SESSION_ENDPOINT=https://${AUTH0_DOMAIN}/v2/logout
 OAUTH_CLIENT_ID=your-auth0-client-id
 OAUTH_CLIENT_SECRET=your-auth0-client-secret
+OAUTH_AUDIENCE=https://api.example.com
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback
 POST_LOGOUT_REDIRECT_URI=http://localhost:8080
 OAUTH_SCOPES=openid,email,profile
@@ -495,6 +497,7 @@ SESSION_MAX_AGE=30
 5. Add Allowed Callback URLs: `http://localhost:8080/auth/callback`
 6. Add Allowed Logout URLs: `http://localhost:8080`
 7. Copy Domain, Client ID, and Client Secret
+8. If you need access tokens for a custom API, set `OAUTH_AUDIENCE` to that API's Auth0 Identifier and pass it with `with_audience(...)`
 
 ---
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -6,7 +6,7 @@ A quick reference guide for common tasks and API usage.
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.6"
+axum-oidc-client = "0.7"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -29,6 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = OAuthConfigurationBuilder::default()
         .with_client_id("your-client-id")
         .with_client_secret("your-client-secret")
+        .with_audience("https://api.example.com")  // Optional: request an API/resource audience
         .with_redirect_uri("http://localhost:8080/auth/callback")
         .with_authorization_endpoint("https://provider.com/oauth/authorize")
         .with_token_endpoint("https://provider.com/oauth/token")
@@ -199,6 +200,7 @@ OAuthConfigurationBuilder::default()
     // Required
     .with_client_id("client-id")
     .with_client_secret("client-secret")
+    .with_audience("https://api.example.com")  // Optional: request an API/resource audience
     .with_redirect_uri("http://localhost:8080/auth/callback")
     .with_authorization_endpoint("https://provider.com/authorize")
     .with_token_endpoint("https://provider.com/token")
@@ -219,6 +221,7 @@ OAuthConfigurationBuilder::default()
 
 | Setting | Default | When to change |
 |---------|---------|----------------|
+| `with_audience(audience)` | unset | Set when the provider needs an API/resource identifier in the authorization request (e.g. Auth0 access tokens for custom APIs) |
 | `with_token_request_redirect_uri(bool)` | `true` | Set `false` if the provider returns `invalid_request` during token exchange because it rejects a redundant `redirect_uri` (e.g. Okta with a single registered redirect URI) |
 
 ## Route Handlers
@@ -402,9 +405,9 @@ Requires one of the `sql-cache-*` feature flags. An alternative L2 backend to Re
 
 ```toml
 # Choose one (or use sql-cache-all for testing):
-axum-oidc-client = { version = "0.6", features = ["sql-cache-sqlite"] }
-axum-oidc-client = { version = "0.6", features = ["sql-cache-postgres"] }
-axum-oidc-client = { version = "0.6", features = ["sql-cache-mysql"] }
+axum-oidc-client = { version = "0.7", features = ["sql-cache-sqlite"] }
+axum-oidc-client = { version = "0.7", features = ["sql-cache-postgres"] }
+axum-oidc-client = { version = "0.7", features = ["sql-cache-mysql"] }
 ```
 
 ```rust
@@ -916,19 +919,19 @@ async fn test_refresh(session: AuthSession) -> String {
 
 ```toml
 # Default features (server + authentication + jwt + moka-cache + reqwest-rustls-tls)
-axum-oidc-client = "0.6"
+axum-oidc-client = "0.7"
 
 # Add Redis support
-axum-oidc-client = { version = "0.6", features = ["redis"] }
+axum-oidc-client = { version = "0.7", features = ["redis"] }
 
 # JWT only (no OAuth2 session layer)
-axum-oidc-client = { version = "0.6", default-features = false, features = ["jwt", "reqwest-rustls-tls"] }
+axum-oidc-client = { version = "0.7", default-features = false, features = ["jwt", "reqwest-rustls-tls"] }
 
 # Authentication only (no JWT layer)
-axum-oidc-client = { version = "0.6", default-features = false, features = ["server", "authentication", "moka-cache", "reqwest-rustls-tls"] }
+axum-oidc-client = { version = "0.7", default-features = false, features = ["server", "authentication", "moka-cache", "reqwest-rustls-tls"] }
 
 # WASM target (no server feature)
-axum-oidc-client = { version = "0.6", default-features = false, features = ["wasm", "reqwest-rustls-tls"] }
+axum-oidc-client = { version = "0.7", default-features = false, features = ["wasm", "reqwest-rustls-tls"] }
 ```
 
 ## Testing
@@ -966,5 +969,5 @@ openssl rand -hex 32
 
 ---
 
-**Version:** 0.6.0  
-**Last Updated:** 2026-05-26
+**Version:** 0.7.0  
+**Last Updated:** 2026-06-04

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A comprehensive OAuth2/OIDC authentication library for Axum web applications wit
 - 🍪 **Secure Sessions** - Encrypted cookie-based session management
 - 🚪 **Logout Handlers** - Support for both standard and OIDC logout flows
 - 🎯 **Type-safe Extractors** - Convenient extractors for authenticated users and sessions
-- 🔧 **Customizable** - Extensible with custom CA certificates and logout handlers
+- 🔧 **Customizable** - Extensible with custom CA certificates, logout handlers, and authorization-request audience
 - ⚡ **Production Ready** - Battle-tested with comprehensive error handling
 
 ## Installation
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-axum-oidc-client = "0.6"
+axum-oidc-client = "0.7"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -61,25 +61,25 @@ tokio = { version = "1", features = ["full"] }
 ```toml
 [dependencies]
 # Default: includes server, authentication, jwt, moka-cache, and reqwest-rustls-tls features
-axum-oidc-client = "0.6"
+axum-oidc-client = "0.7"
 
 # With JWT validation + Redis cache backend
-axum-oidc-client = { version = "0.6", features = ["jwt", "redis"] }
+axum-oidc-client = { version = "0.7", features = ["jwt", "redis"] }
 
 # With Redis + two-tier cache (L1 Moka + L2 Redis)
-axum-oidc-client = { version = "0.6", features = ["moka-cache", "redis"] }
+axum-oidc-client = { version = "0.7", features = ["moka-cache", "redis"] }
 
 # With PostgreSQL cache backend
-axum-oidc-client = { version = "0.6", features = ["sql-cache-postgres"] }
+axum-oidc-client = { version = "0.7", features = ["sql-cache-postgres"] }
 
 # With SQLite cache backend (great for development)
-axum-oidc-client = { version = "0.6", features = ["sql-cache-sqlite"] }
+axum-oidc-client = { version = "0.7", features = ["sql-cache-sqlite"] }
 
 # With Moka L1 + PostgreSQL L2 two-tier cache
-axum-oidc-client = { version = "0.6", features = ["moka-cache", "sql-cache-postgres"] }
+axum-oidc-client = { version = "0.7", features = ["moka-cache", "sql-cache-postgres"] }
 
 # WASM target (wasm32-unknown-unknown): disable defaults, enable wasm feature
-axum-oidc-client = { version = "0.6", default-features = false, features = ["wasm"] }
+axum-oidc-client = { version = "0.7", default-features = false, features = ["wasm"] }
 ```
 
 ## Quick Start
@@ -102,6 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_token_endpoint("https://oauth2.googleapis.com/token")
         .with_client_id("your-client-id")
         .with_client_secret("your-client-secret")
+        .with_audience("https://api.example.com") // Optional: request an API/resource audience
         .with_redirect_uri("http://localhost:8080/auth/callback")
         .with_private_cookie_key("your-secret-key-at-least-32-bytes")
         .with_scopes(vec!["openid", "email", "profile"])

--- a/examples/.env.azure.example
+++ b/examples/.env.azure.example
@@ -27,6 +27,8 @@ OAUTH_ISSUER=https://login.microsoftonline.com/${AZURE_TENANT}/v2.0
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-application-client-id
 OAUTH_CLIENT_SECRET=your-client-secret-value
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.github.example
+++ b/examples/.env.github.example
@@ -25,6 +25,8 @@ OAUTH_TOKEN_ENDPOINT=https://github.com/login/oauth/access_token
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-github-client-id
 OAUTH_CLIENT_SECRET=your-github-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.google.example
+++ b/examples/.env.google.example
@@ -23,6 +23,11 @@ OAUTH_ISSUER=https://accounts.google.com
 OAUTH_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 OAUTH_CLIENT_SECRET=your-google-client-secret
 
+# for Google OIDC, `aud` in ID token is normally client ID automatically
+# WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=1234567890-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
+
+
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback
 

--- a/examples/.env.keycloak.example
+++ b/examples/.env.keycloak.example
@@ -33,6 +33,8 @@ OAUTH_ISSUER=${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-client-id
 OAUTH_CLIENT_SECRET=your-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.mysql.example
+++ b/examples/.env.mysql.example
@@ -18,6 +18,8 @@ OAUTH_ISSUER=https://accounts.google.com
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-client-id
 OAUTH_CLIENT_SECRET=your-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.postgres.example
+++ b/examples/.env.postgres.example
@@ -18,6 +18,8 @@ OAUTH_ISSUER=https://accounts.google.com
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-client-id
 OAUTH_CLIENT_SECRET=your-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.redis.example
+++ b/examples/.env.redis.example
@@ -18,6 +18,8 @@ OAUTH_ISSUER=https://accounts.google.com
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-client-id
 OAUTH_CLIENT_SECRET=your-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/.env.sqlite.example
+++ b/examples/.env.sqlite.example
@@ -25,6 +25,8 @@ OAUTH_ISSUER=https://accounts.google.com
 # ── Credentials ───────────────────────────────────────────────────────────────
 OAUTH_CLIENT_ID=your-client-id
 OAUTH_CLIENT_SECRET=your-client-secret
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
 
 # ── Callback URI ──────────────────────────────────────────────────────────────
 OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/examples/ENV_FILES_GUIDE.md
+++ b/examples/ENV_FILES_GUIDE.md
@@ -37,7 +37,7 @@ Edit `.env` and replace the placeholder values:
 
 - `OAUTH_CLIENT_ID` - Your OAuth2 client ID
 - `OAUTH_CLIENT_SECRET` - Your OAuth2 client secret
-- `OAUTH_AUDIENCE` - Optional API/resource identifier for providers that require one
+- `WWW_OAUTH_AUDIENCE` / `API_OAUTH_AUDIENCE` - Optional per-service audience values (no default)
 - `PRIVATE_COOKIE_KEY` - Generate with: `openssl rand -base64 64`
 
 ### 3. Run the Application
@@ -102,8 +102,14 @@ OAUTH_BASE_PATH=/api/auth
 # Post-logout redirect (default: /)
 POST_LOGOUT_REDIRECT_URI=http://localhost:8080/home
 
-# Authorization-request audience/API resource identifier
-OAUTH_AUDIENCE=https://api.example.com
+# Optional audience requested by www-server and validated by api-server.
+# No default is applied when unset.
+# For Google OIDC, `aud` in ID token is normally client ID automatically.
+WWW_OAUTH_AUDIENCE=https://example.com
+API_OAUTH_AUDIENCE=https://example.com
+
+# Legacy shared audience fallback (used only when service-specific vars are unset)
+# OAUTH_AUDIENCE=https://example.com
 
 # PKCE method (default: S256)
 CODE_CHALLENGE_METHOD=S256

--- a/examples/ENV_FILES_GUIDE.md
+++ b/examples/ENV_FILES_GUIDE.md
@@ -37,6 +37,7 @@ Edit `.env` and replace the placeholder values:
 
 - `OAUTH_CLIENT_ID` - Your OAuth2 client ID
 - `OAUTH_CLIENT_SECRET` - Your OAuth2 client secret
+- `OAUTH_AUDIENCE` - Optional API/resource identifier for providers that require one
 - `PRIVATE_COOKIE_KEY` - Generate with: `openssl rand -base64 64`
 
 ### 3. Run the Application
@@ -100,6 +101,9 @@ OAUTH_BASE_PATH=/api/auth
 
 # Post-logout redirect (default: /)
 POST_LOGOUT_REDIRECT_URI=http://localhost:8080/home
+
+# Authorization-request audience/API resource identifier
+OAUTH_AUDIENCE=https://api.example.com
 
 # PKCE method (default: S256)
 CODE_CHALLENGE_METHOD=S256

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,6 +11,8 @@
 #
 # Usage:
 #   make                   → this help
+#   make run               → run api-server + www-server locally
+#   make dev               → watch-run api-server + www-server locally
 #   make l1-up             → start L1-only stack (no external backend)
 #   make pg-up             → start PostgreSQL stack
 #   make redis-up          → start Redis stack
@@ -19,11 +21,33 @@
 
 # ── Variables ──────────────────────────────────────────────────────────────────
 
+SHELL := /bin/bash
+
+# Resolve the directory of THIS Makefile so forwarded paths work regardless of cwd.
+THIS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # Shared env file — lives in examples/, passed to every docker compose call.
 ENV_FILE ?= $(or $(DOTENV_FILE),.env.local)
+ENV_FILE_ABS = $(if $(filter /%,$(ENV_FILE)),$(ENV_FILE),$(THIS_DIR)$(ENV_FILE))
 
 # Host-side port exposed by www-server (override: WWW_PORT=9090 make l1-up)
 WWW_PORT ?= 8080
+
+# Local development bind settings for parent run/dev targets.
+HOST ?= 127.0.0.1
+API_PORT ?= 8181
+
+# Optional audience overrides for parent run/dev targets.
+# Undefined by default so DOTENV_FILE values can be loaded by the sub-servers.
+WWW_AUDIENCE_ARG = $(if $(strip $(WWW_OAUTH_AUDIENCE)),WWW_OAUTH_AUDIENCE=$(WWW_OAUTH_AUDIENCE))
+API_AUDIENCE_ARG = $(if $(strip $(API_OAUTH_AUDIENCE)),API_OAUTH_AUDIENCE=$(API_OAUTH_AUDIENCE))
+
+# Cargo feature set forwarded to www-server run/dev targets.
+FEATURES ?= cache-l1
+
+# Sub-project paths
+WWW_SERVER_DIR      = www-server
+API_SERVER_DIR      = api-server
 
 # Docker Compose file paths
 DOCKER_DIR          = docker
@@ -52,12 +76,72 @@ NC     = \033[0m
 
 .DEFAULT_GOAL := help
 
+# ── local development ─────────────────────────────────────────────────────────
+
+.PHONY: run
+run:
+	@echo -e "$(GREEN)Starting api-server + www-server…$(NC)"
+	@echo -e "$(BLUE)  api-server : http://$(HOST):$(API_PORT)$(NC)"
+	@echo -e "$(BLUE)  www-server : http://$(HOST):$(WWW_PORT)$(NC)"
+	@echo -e "$(YELLOW)  Press Ctrl-C to stop both$(NC)"
+	@$(MAKE) -C $(API_SERVER_DIR) run \
+		HOST=$(HOST) \
+		PORT=$(API_PORT) \
+		$(API_AUDIENCE_ARG) \
+		DOTENV_FILE="$(ENV_FILE_ABS)" & \
+		api_pid=$$!; \
+	$(MAKE) -C $(WWW_SERVER_DIR) run \
+		HOST=$(HOST) \
+		PORT=$(WWW_PORT) \
+		FEATURES=$(FEATURES) \
+		API_SERVER="http://$(HOST):$(API_PORT)" \
+		$(WWW_AUDIENCE_ARG) \
+		DOTENV_FILE="$(ENV_FILE_ABS)" & \
+		www_pid=$$!; \
+	trap 'kill $$api_pid $$www_pid 2>/dev/null || true; wait 2>/dev/null || true; exit 0' INT TERM; \
+	wait -n $$api_pid $$www_pid; status=$$?; \
+	kill $$api_pid $$www_pid 2>/dev/null || true; \
+	wait $$api_pid $$www_pid 2>/dev/null || true; \
+	if [ $$status -eq 130 ] || [ $$status -eq 143 ]; then exit 0; fi; \
+	exit $$status
+
+.PHONY: dev
+dev:
+	@echo -e "$(GREEN)Starting api-server + www-server with hot-reload…$(NC)"
+	@echo -e "$(BLUE)  api-server : http://$(HOST):$(API_PORT)$(NC)"
+	@echo -e "$(BLUE)  www-server : http://$(HOST):$(WWW_PORT)$(NC)"
+	@echo -e "$(YELLOW)  Press Ctrl-C to stop both$(NC)"
+	@$(MAKE) -C $(API_SERVER_DIR) dev \
+		HOST=$(HOST) \
+		PORT=$(API_PORT) \
+		$(API_AUDIENCE_ARG) \
+		DOTENV_FILE="$(ENV_FILE_ABS)" & \
+		api_pid=$$!; \
+	$(MAKE) -C $(WWW_SERVER_DIR) dev \
+		HOST=$(HOST) \
+		PORT=$(WWW_PORT) \
+		FEATURES=$(FEATURES) \
+		API_SERVER="http://$(HOST):$(API_PORT)" \
+		$(WWW_AUDIENCE_ARG) \
+		DOTENV_FILE="$(ENV_FILE_ABS)" & \
+		www_pid=$$!; \
+	trap 'kill $$api_pid $$www_pid 2>/dev/null || true; wait 2>/dev/null || true; exit 0' INT TERM; \
+	wait -n $$api_pid $$www_pid; status=$$?; \
+	kill $$api_pid $$www_pid 2>/dev/null || true; \
+	wait $$api_pid $$www_pid 2>/dev/null || true; \
+	if [ $$status -eq 130 ] || [ $$status -eq 143 ]; then exit 0; fi; \
+	exit $$status
+
 # ── help ───────────────────────────────────────────────────────────────────────
 
 .PHONY: help
 help:
 	@echo -e "$(GREEN)Examples — Docker Compose targets$(NC)"
-	@echo -e "$(BLUE)For cargo targets (run, dev, build, test, …) use the sub-Makefiles:$(NC)"
+	@echo -e "$(YELLOW)Local development:$(NC)"
+	@echo "  make run           - Run api-server + www-server locally"
+	@echo "  make dev           - Watch-run api-server + www-server locally"
+	@echo ""
+	@echo -e "$(BLUE)For other cargo targets (build, test, …) use the sub-Makefiles:$(NC)"
 	@echo "  make -C www-server help"
 	@echo "  make -C api-server help"
 	@echo ""
@@ -103,8 +187,13 @@ help:
 	@echo "  make sqlite-shell    - Open sqlite3 shell"
 	@echo ""
 	@echo -e "$(BLUE)Variable overrides:$(NC)"
-	@echo "  WWW_PORT=$(WWW_PORT)        host-side port for www-server"
-	@echo "  DOTENV_FILE=<path>    shared env file (default: $(ENV_FILE))"
+	@echo "  HOST=$(HOST)                    bind host for local run/dev"
+	@echo "  API_PORT=$(API_PORT)                 api-server port for local run/dev"
+	@echo "  WWW_PORT=$(WWW_PORT)                 www-server port"
+	@echo "  FEATURES=$(FEATURES)             www-server cargo features for local run/dev"
+	@echo "  WWW_OAUTH_AUDIENCE=<value>  optional override; unset lets DOTENV_FILE decide"
+	@echo "  API_OAUTH_AUDIENCE=<value>  optional override; unset lets DOTENV_FILE decide"
+	@echo "  DOTENV_FILE=<path>             shared env file (default: $(ENV_FILE))"
 
 # ── L1 (Moka in-process, no external backend) ─────────────────────────────────
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -968,6 +968,7 @@ All CLI arguments can be set via environment variables:
 | ---------------------------- | ------------------------------ | -------- | -------------------------------------------- |
 | `--client-id`                | `OAUTH_CLIENT_ID`              | Yes      | —                                            |
 | `--client-secret`            | `OAUTH_CLIENT_SECRET`          | Yes      | —                                            |
+| `--audience`                 | `OAUTH_AUDIENCE`               | No       | — (authorization-request API/resource identifier) |
 | `--issuer`                   | `OAUTH_ISSUER`                 | No       | — (enables OIDC autodiscovery when set)      |
 | `--authorization-endpoint`   | `OAUTH_AUTHORIZATION_ENDPOINT` | No       | — (required when `--issuer` is not set)      |
 | `--token-endpoint`           | `OAUTH_TOKEN_ENDPOINT`         | No       | — (required when `--issuer` is not set)      |

--- a/examples/api-server/Cargo.toml
+++ b/examples/api-server/Cargo.toml
@@ -10,6 +10,7 @@ tokio               = { version = "1.41", features = ["full"] }
 serde               = { version = "1.0", features = ["derive"] }
 serde_json          = "1.0"
 clap                = { version = "4", features = ["derive", "env"] }
+dotenv              = "0.15"
 tower               = "0.5"
 tracing             = "0.1"
 tracing-subscriber  = { version = "0.3", features = ["env-filter"] }

--- a/examples/api-server/Makefile
+++ b/examples/api-server/Makefile
@@ -14,6 +14,7 @@
 #
 # Key variables read from the shared file:
 #   OAUTH_ISSUER       OIDC issuer URL for JWT validation  (required)
+#   API_OAUTH_AUDIENCE Optional expected JWT audience
 #   CUSTOM_CA_CERT     path to PEM CA cert                  (optional)
 #   SERVER_HOST        bind address                         (default: 127.0.0.1)
 #   SERVER_PORT        bind port                            (default: 8181)
@@ -82,6 +83,7 @@ help:
 	@echo -e "$(BLUE)Environment / overrides:$(NC)"
 	@echo "  HOST=$(HOST)      (override: HOST=0.0.0.0 make run)"
 	@echo "  PORT=$(PORT)      (override: PORT=9090 make run)"
+	@echo "  API_OAUTH_AUDIENCE=<value>  optional audience validation"
 	@echo "  ENV_FILE=$(ENV_FILE)"
 	@echo "  DOTENV_FILE=<path> make run   (use a custom dotenv file)"
 	@echo ""
@@ -94,8 +96,9 @@ help:
 	@echo "  OAUTH_ISSUER     OIDC issuer URL  (e.g. https://accounts.google.com)"
 	@echo ""
 	@echo -e "$(BLUE)Optional configuration:$(NC)"
-	@echo "  CUSTOM_CA_CERT   Path to a PEM CA certificate for private OIDC providers"
-	@echo "  SERVER_HOST      Bind address          (default: 127.0.0.1)"
+	@echo "  API_OAUTH_AUDIENCE  Optional expected JWT audience"
+	@echo "  CUSTOM_CA_CERT       Path to a PEM CA certificate for private OIDC providers"
+	@echo "  SERVER_HOST          Bind address          (default: 127.0.0.1)"
 	@echo "  SERVER_PORT      Bind port             (default: 8181)"
 
 # ── install ────────────────────────────────────────────────────────────────────

--- a/examples/api-server/src/main.rs
+++ b/examples/api-server/src/main.rs
@@ -28,8 +28,10 @@
 //! |-------------------------------|---------------|------------------------------------------------------|
 //! | `--host` / `SERVER_HOST`      | `127.0.0.1`   | Bind address                                         |
 //! | `--port` / `SERVER_PORT`      | `8181`        | Bind port                                            |
-//! | `--issuer` / `JWT_ISSUER`     | *(required)*  | OIDC issuer URL; discovery doc fetched automatically |
+//! | `--issuer` / `OAUTH_ISSUER`   | *(required)*  | OIDC issuer URL; discovery doc fetched automatically |
+//! | `--audience` / `API_OAUTH_AUDIENCE` | *(none)* | Expected JWT `aud` claim                     |
 //! | `--custom-ca-cert` / `CUSTOM_CA_CERT` | *(none)* | PEM CA cert for private OIDC providers            |
+//! | `DOTENV_FILE`                    | *(none)*      | Dotenv file loaded before CLI/env parsing         |
 //!
 //! ## Quick start
 //!
@@ -42,7 +44,7 @@
 mod layers;
 mod routes;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{env, net::SocketAddr, sync::Arc};
 
 use axum::{Router, routing::get};
 use clap::Parser;
@@ -71,10 +73,47 @@ struct Args {
     #[arg(long, env = "OAUTH_ISSUER")]
     issuer: String,
 
+    /// Expected OAuth2/OIDC audience in incoming JWTs.
+    ///
+    /// Resolution order: CLI `--audience`, `API_OAUTH_AUDIENCE`, then legacy
+    /// `OAUTH_AUDIENCE`.
+    #[arg(long)]
+    audience: Option<String>,
+
     /// Path to a PEM-encoded custom CA certificate for HTTPS requests to the
     /// OIDC issuer.  Only required when the provider uses a private CA.
     #[arg(long, env = "CUSTOM_CA_CERT")]
     custom_ca_cert: Option<String>,
+}
+
+impl Args {
+    fn load_dotenv() {
+        if let Ok(path) = env::var("DOTENV_FILE") {
+            let _ = dotenv::from_path(path);
+            return;
+        }
+
+        let _ = dotenv::from_filename("../.env.local")
+            .or_else(|_| dotenv::from_filename(".env.local"))
+            .or_else(|_| dotenv::dotenv());
+    }
+
+    fn parse_and_load() -> Self {
+        Self::load_dotenv();
+        Self::parse()
+    }
+
+    fn env_non_empty(key: &str) -> Option<String> {
+        env::var(key).ok().filter(|value| !value.trim().is_empty())
+    }
+
+    fn resolved_audience(&self) -> Option<String> {
+        self.audience
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| Self::env_non_empty("API_OAUTH_AUDIENCE"))
+            .or_else(|| Self::env_non_empty("OAUTH_AUDIENCE"))
+    }
 }
 
 // ── entry point ───────────────────────────────────────────────────────────────
@@ -85,7 +124,7 @@ async fn main() {
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();
 
-    let args = Args::parse();
+    let args = Args::parse_and_load();
 
     // ── Build JwtConfiguration via OIDC auto-discovery ────────────────────────
     info!("Fetching OIDC discovery document from {}", args.issuer);
@@ -96,10 +135,17 @@ async fn main() {
         builder = builder.with_custom_ca_cert(path);
     }
 
-    let builder = builder.with_issuer(&args.issuer).await.unwrap_or_else(|e| {
+    let mut builder = builder.with_issuer(&args.issuer).await.unwrap_or_else(|e| {
         eprintln!("error: OIDC discovery failed for {}: {e}", args.issuer);
         std::process::exit(1);
     });
+
+    if let Some(audience) = args.resolved_audience() {
+        info!("Validating JWT audience: {audience}");
+        builder = builder.with_audience(vec![audience]);
+    } else {
+        info!("JWT audience validation disabled; set API_OAUTH_AUDIENCE to enable it");
+    }
 
     let jwt_config = builder.build().unwrap_or_else(|e| {
         eprintln!("error: failed to build JWT configuration: {e}");

--- a/examples/docker/docker-compose.l1.yml
+++ b/examples/docker/docker-compose.l1.yml
@@ -70,6 +70,7 @@ x-app-env: &app-env
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}
   OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
   OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+  OAUTH_AUDIENCE: ${OAUTH_AUDIENCE:-}
   OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-http://localhost:8080/auth/callback}
   PRIVATE_COOKIE_KEY: ${PRIVATE_COOKIE_KEY:-change-me-in-production}
 
@@ -91,6 +92,7 @@ services:
 
     environment:
       <<: *app-env
+      API_OAUTH_AUDIENCE: ${API_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8181"
 
@@ -126,6 +128,7 @@ services:
 
     environment:
       <<: *app-env
+      WWW_OAUTH_AUDIENCE: ${WWW_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8080"
       # Point www-server's reverse proxy at the api-server service name.

--- a/examples/docker/docker-compose.mysql.yml
+++ b/examples/docker/docker-compose.mysql.yml
@@ -65,6 +65,7 @@ x-app-env: &app-env
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}
   OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
   OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+  OAUTH_AUDIENCE: ${OAUTH_AUDIENCE:-}
   OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-http://localhost:8080/auth/callback}
   PRIVATE_COOKIE_KEY: ${PRIVATE_COOKIE_KEY:-change-me-in-production}
 
@@ -212,6 +213,7 @@ services:
 
     environment:
       <<: *app-env
+      API_OAUTH_AUDIENCE: ${API_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8181"
 
@@ -246,6 +248,7 @@ services:
 
     environment:
       <<: *app-env
+      WWW_OAUTH_AUDIENCE: ${WWW_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8080"
       # Point www-server's reverse proxy at the api-server service name.

--- a/examples/docker/docker-compose.postgres.yml
+++ b/examples/docker/docker-compose.postgres.yml
@@ -49,6 +49,7 @@ x-app-env: &app-env
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}
   OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
   OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+  OAUTH_AUDIENCE: ${OAUTH_AUDIENCE:-}
   OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-http://localhost:8080/auth/callback}
   PRIVATE_COOKIE_KEY: ${PRIVATE_COOKIE_KEY:-change-me-in-production}
 
@@ -175,6 +176,7 @@ services:
 
     environment:
       <<: *app-env
+      API_OAUTH_AUDIENCE: ${API_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8181"
 
@@ -209,6 +211,7 @@ services:
 
     environment:
       <<: *app-env
+      WWW_OAUTH_AUDIENCE: ${WWW_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8080"
       # Point www-server's reverse proxy at the api-server service name.

--- a/examples/docker/docker-compose.redis.yml
+++ b/examples/docker/docker-compose.redis.yml
@@ -61,6 +61,7 @@ x-app-env: &app-env
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}
   OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
   OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+  OAUTH_AUDIENCE: ${OAUTH_AUDIENCE:-}
   OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-http://localhost:8080/auth/callback}
   PRIVATE_COOKIE_KEY: ${PRIVATE_COOKIE_KEY:-change-me-in-production}
 
@@ -157,6 +158,7 @@ services:
 
     environment:
       <<: *app-env
+      API_OAUTH_AUDIENCE: ${API_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8181"
 
@@ -191,6 +193,7 @@ services:
 
     environment:
       <<: *app-env
+      WWW_OAUTH_AUDIENCE: ${WWW_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8080"
       # Point www-server's reverse proxy at the api-server service name.

--- a/examples/docker/docker-compose.sqlite.yml
+++ b/examples/docker/docker-compose.sqlite.yml
@@ -86,6 +86,7 @@ x-app-env: &app-env
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}
   OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-}
   OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-}
+  OAUTH_AUDIENCE: ${OAUTH_AUDIENCE:-}
   OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-http://localhost:8080/auth/callback}
   PRIVATE_COOKIE_KEY: ${PRIVATE_COOKIE_KEY:-change-me-in-production}
 
@@ -139,6 +140,7 @@ services:
 
     environment:
       <<: *app-env
+      API_OAUTH_AUDIENCE: ${API_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8181"
 
@@ -173,6 +175,7 @@ services:
 
     environment:
       <<: *app-env
+      WWW_OAUTH_AUDIENCE: ${WWW_OAUTH_AUDIENCE:-}
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "8080"
       # Point www-server's reverse proxy at the api-server service name.

--- a/examples/www-server/Makefile
+++ b/examples/www-server/Makefile
@@ -21,6 +21,7 @@
 #   OAUTH_CLIENT_SECRET     OAuth2 client secret                (required)
 #   OAUTH_REDIRECT_URI      Callback URI                        (default: http://localhost:8080/auth/callback)
 #   PRIVATE_COOKIE_KEY      Session encryption key              (change in prod!)
+#   WWW_OAUTH_AUDIENCE      Optional audience requested from provider
 #   SERVER_HOST / SERVER_PORT
 #   API_SERVER              upstream api-server base URL        (default: http://127.0.0.1:8181)
 
@@ -185,6 +186,7 @@ help:
 	@echo "  HOST=$(HOST)        (override: HOST=0.0.0.0 make run)"
 	@echo "  PORT=$(PORT)        (override: PORT=3000 make run)"
 	@echo "  FEATURES=$(FEATURES)   (override: FEATURES=cache-l2 make run)"
+	@echo "  WWW_OAUTH_AUDIENCE=<value>  optional audience override"
 	@echo "  ENV_FILE=$(ENV_FILE)"
 	@echo "  DOTENV_FILE=<path> make run  (use a custom dotenv file)"
 	@echo ""
@@ -259,6 +261,9 @@ setup:
 			printf '# Scopes (www-server)\n'                                                  >> "$(ENV_FILE)"; \
 			printf 'OAUTH_SCOPES=openid,email,profile\n'                                      >> "$(ENV_FILE)"; \
 			printf '\n'                                                                        >> "$(ENV_FILE)"; \
+			printf '# Optional audience requested by www-server\n'                         >> "$(ENV_FILE)"; \
+			printf '# WWW_OAUTH_AUDIENCE=\n'                                                >> "$(ENV_FILE)"; \
+			printf '\n'                                                                        >> "$(ENV_FILE)"; \
 			printf '# ── www-server ───────────────────────────────────────────────────────\n' >> "$(ENV_FILE)"; \
 			printf 'SERVER_HOST=$(HOST)\n'                                                    >> "$(ENV_FILE)"; \
 			printf 'SERVER_PORT=$(PORT)\n'                                                    >> "$(ENV_FILE)"; \
@@ -267,6 +272,8 @@ setup:
 			printf 'API_SERVER=http://127.0.0.1:8181\n'                                       >> "$(ENV_FILE)"; \
 			printf '\n'                                                                        >> "$(ENV_FILE)"; \
 			printf '# ── api-server ───────────────────────────────────────────────────────\n' >> "$(ENV_FILE)"; \
+			printf '# Optional JWT audience validated by api-server\n'                      >> "$(ENV_FILE)"; \
+			printf '# API_OAUTH_AUDIENCE=\n'                                                >> "$(ENV_FILE)"; \
 			printf '# SERVER_HOST=127.0.0.1\n'                                                >> "$(ENV_FILE)"; \
 			printf '# SERVER_PORT=8181\n'                                                     >> "$(ENV_FILE)"; \
 			printf '\n'                                                                        >> "$(ENV_FILE)"; \

--- a/examples/www-server/src/config.rs
+++ b/examples/www-server/src/config.rs
@@ -193,6 +193,13 @@ pub struct Args {
     #[arg(long, env = "OAUTH_CLIENT_SECRET")]
     pub client_secret: String,
 
+    /// Optional OAuth2/OIDC audience/resource identifier.
+    ///
+    /// When set, this is sent as the `audience` query parameter on the
+    /// authorization request.
+    #[arg(long, env = "OAUTH_AUDIENCE")]
+    pub audience: Option<String>,
+
     // ── URIs & keys ───────────────────────────────────────────────────────────
     /// OAuth2 redirect (callback) URI.
     #[arg(
@@ -601,6 +608,10 @@ impl Args {
             .with_code_challenge_method(self.code_challenge_method.clone())
             .with_base_path(&self.base_path);
 
+        if let Some(audience) = self.audience.as_deref() {
+            b = b.with_audience(audience);
+        }
+
         b.build()
             .map_err(|e| format!("Failed to build OAuth configuration: {e:?}"))
     }
@@ -622,6 +633,7 @@ impl Args {
             "OAUTH_ISSUER",
             "OAUTH_CLIENT_ID",
             "OAUTH_CLIENT_SECRET",
+            "OAUTH_AUDIENCE",
             "OAUTH_AUTHORIZATION_ENDPOINT",
             "OAUTH_TOKEN_ENDPOINT",
             "OAUTH_END_SESSION_ENDPOINT",

--- a/examples/www-server/src/config.rs
+++ b/examples/www-server/src/config.rs
@@ -193,11 +193,14 @@ pub struct Args {
     #[arg(long, env = "OAUTH_CLIENT_SECRET")]
     pub client_secret: String,
 
-    /// Optional OAuth2/OIDC audience/resource identifier.
+    /// OAuth2/OIDC audience/resource identifier.
+    ///
+    /// Resolution order: CLI `--audience`, `WWW_OAUTH_AUDIENCE`, then legacy
+    /// `OAUTH_AUDIENCE`.
     ///
     /// When set, this is sent as the `audience` query parameter on the
     /// authorization request.
-    #[arg(long, env = "OAUTH_AUDIENCE")]
+    #[arg(long)]
     pub audience: Option<String>,
 
     // ── URIs & keys ───────────────────────────────────────────────────────────
@@ -543,6 +546,18 @@ impl Args {
 
     // ── Configuration building ────────────────────────────────────────────────
 
+    fn env_non_empty(key: &str) -> Option<String> {
+        env::var(key).ok().filter(|value| !value.trim().is_empty())
+    }
+
+    fn resolved_audience(&self) -> Option<String> {
+        self.audience
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| Self::env_non_empty("WWW_OAUTH_AUDIENCE"))
+            .or_else(|| Self::env_non_empty("OAUTH_AUDIENCE"))
+    }
+
     /// Build an [`OAuthConfiguration`] from the parsed arguments.
     ///
     /// When `--issuer` (or `OAUTH_ISSUER`) is set the builder fetches the
@@ -608,8 +623,8 @@ impl Args {
             .with_code_challenge_method(self.code_challenge_method.clone())
             .with_base_path(&self.base_path);
 
-        if let Some(audience) = self.audience.as_deref() {
-            b = b.with_audience(audience);
+        if let Some(audience) = self.resolved_audience() {
+            b = b.with_audience(&audience);
         }
 
         b.build()
@@ -633,6 +648,7 @@ impl Args {
             "OAUTH_ISSUER",
             "OAUTH_CLIENT_ID",
             "OAUTH_CLIENT_SECRET",
+            "WWW_OAUTH_AUDIENCE",
             "OAUTH_AUDIENCE",
             "OAUTH_AUTHORIZATION_ENDPOINT",
             "OAUTH_TOKEN_ENDPOINT",

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -190,6 +190,8 @@ pub struct OAuthConfigurationBuilder {
     pub client_id: Option<String>,
     /// OAuth2 client secret
     pub client_secret: Option<String>,
+    /// Optional OAuth2/OIDC audience to request at the authorization endpoint
+    pub audience: Option<String>,
     /// Redirect URI for OAuth2 callback
     pub redirect_uri: Option<String>,
     /// See [`OAuthConfiguration::token_request_redirect_uri`].
@@ -228,6 +230,7 @@ impl Default for OAuthConfigurationBuilder {
             private_cookie_key: None,
             client_id: None,
             client_secret: None,
+            audience: None,
             redirect_uri: None,
             token_request_redirect_uri: true,
             authorization_endpoint: None,
@@ -460,6 +463,30 @@ impl OAuthConfigurationBuilder {
     pub fn with_client_secret(self, client_secret: &str) -> Self {
         Self {
             client_secret: Some(client_secret.to_string()),
+            ..self
+        }
+    }
+
+    /// Set the optional OAuth2/OIDC audience.
+    ///
+    /// When set, the value is sent as the `audience` query parameter on the
+    /// authorization request.
+    ///
+    /// # Arguments
+    ///
+    /// * `audience` - The API/resource identifier requested from the provider
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_audience("https://api.example.com");
+    /// ```
+    pub fn with_audience(self, audience: &str) -> Self {
+        Self {
+            audience: Some(audience.to_string()),
             ..self
         }
     }
@@ -822,6 +849,7 @@ impl OAuthConfigurationBuilder {
             client_secret: self
                 .client_secret
                 .ok_or(Error::MissingPatameter("client_secret".to_string()))?,
+            audience: self.audience,
             redirect_uri: self
                 .redirect_uri
                 .ok_or(Error::MissingPatameter("redirect_uri".to_string()))?,

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -264,6 +264,8 @@ pub struct OAuthConfiguration {
     pub client_id: String,
     /// OAuth2 client secret
     pub client_secret: String,
+    /// Optional OAuth2/OIDC audience to request at the authorization endpoint
+    pub audience: Option<String>,
     /// Redirect URI for OAuth2 callback
     pub redirect_uri: String,
     /// Whether to include `redirect_uri` in the token exchange request.

--- a/src/authentication/router/handle_auth.rs
+++ b/src/authentication/router/handle_auth.rs
@@ -19,22 +19,29 @@ fn create_auth_request(
         authorization_endpoint,
         scopes,
         code_challenge_method,
+        audience,
         ..
     } = configuration;
 
-    let params = [
+    let code_challenge = code_challenge.to_string();
+    let code_challenge_method = format!("{code_challenge_method}");
+    let mut params = vec![
         ("response_type", "code"),
-        ("client_id", client_id),
-        ("redirect_uri", redirect_uri),
+        ("client_id", client_id.as_str()),
+        ("redirect_uri", redirect_uri.as_str()),
         ("access_type", "offline"),
         ("prompt", "consent"),
         ("state", state),
-        ("scope", scopes),
-        ("code_challenge", &code_challenge.to_string()),
-        ("code_challenge_method", &format!("{code_challenge_method}")),
+        ("scope", scopes.as_str()),
+        ("code_challenge", code_challenge.as_str()),
+        ("code_challenge_method", code_challenge_method.as_str()),
     ];
 
-    let url = reqwest::Url::parse_with_params(authorization_endpoint, &params)
+    if let Some(audience) = audience {
+        params.push(("audience", audience.as_str()));
+    }
+
+    let url = reqwest::Url::parse_with_params(authorization_endpoint, params)
         .map_err(|_| Error::NotValidUri(authorization_endpoint.to_string()))?;
     Ok(url.to_string())
 }
@@ -69,4 +76,27 @@ pub async fn handle_auth(
     let url = create_auth_request(&configuration, &code_challenge, &state_with_redirect)?;
 
     Ok(Redirect::temporary(&url).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authentication::router::test_helpers::create_test_config;
+
+    #[test]
+    fn create_auth_request_includes_audience_when_configured() {
+        let mut configuration = create_test_config();
+        configuration.audience = Some("https://api.example.com".to_string());
+        let method: Method = configuration.code_challenge_method.to_owned().into();
+        let (_, code_challenge) = Code::generate_using(method, Length::MAX).into_pair();
+
+        let url = create_auth_request(&configuration, &code_challenge, "test-state")
+            .expect("auth URL should be valid");
+        let url = reqwest::Url::parse(&url).expect("auth URL should parse");
+        let audience = url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "audience").then_some(value.into_owned()));
+
+        assert_eq!(audience.as_deref(), Some("https://api.example.com"));
+    }
 }

--- a/src/authentication/router/test_helpers.rs
+++ b/src/authentication/router/test_helpers.rs
@@ -76,6 +76,7 @@ pub(crate) fn create_test_config() -> OAuthConfiguration {
         private_cookie_key: Key::from(&[0u8; 64]),
         client_id: "test-client".to_string(),
         client_secret: "test-secret".to_string(),
+        audience: None,
         redirect_uri: "http://localhost:8080/auth/callback".to_string(),
         token_request_redirect_uri: true,
         authorization_endpoint: "http://localhost/auth".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //!     .with_token_endpoint("https://oauth2.googleapis.com/token")
 //!     .with_client_id("your-client-id")
 //!     .with_client_secret("your-client-secret")
+//!     .with_audience("https://api.example.com") // Optional: request an API/resource audience
 //!     .with_redirect_uri("http://localhost:8080/auth/callback")
 //!     .with_private_cookie_key("your-secret-key")
 //!     .with_scopes(vec!["openid", "email", "profile"])


### PR DESCRIPTION
## Summary by Sourcery

Add configurable OAuth2/OIDC audience support across the client library and examples, and introduce top-level make targets for running the example stack locally.

New Features:
- Allow configuring an optional OAuth2/OIDC audience on the authorization request via OAuthConfigurationBuilder::with_audience and the new OAuthConfiguration.audience field.
- Enable JWT audience validation in the example api-server with CLI and environment-based configuration, including dotenv loading.
- Add audience configuration for the example www-server, propagating it into the OAuth configuration and authorization request.
- Introduce top-level make run/dev targets to start the example api-server and www-server together with configurable host, ports, features, and per-service audience variables.

Enhancements:
- Extend authorization URL generation to include an audience query parameter when configured and add tests to verify this behavior.
- Wire audience-related environment variables through example Makefiles, docker-compose files, and env guides for consistent configuration across services.
- Update quick reference, main documentation, provider examples, and README to document audience support and bump the crate version to 0.7.0.

Documentation:
- Document the new audience configuration options and usage patterns in QUICK_REFERENCE.md, DOCUMENTATION.md, PROVIDER_EXAMPLES.md, README.md, and example guides.
- Update version references and last-updated metadata in docs to reflect the 0.7.0 release.

Tests:
- Add a unit test ensuring the authorization URL includes the audience parameter when configured.

Chores:
- Bump the crate version from 0.6.1 to 0.7.0 and record the change set in CHANGELOG.md, including a note about the new OAuthConfiguration.audience field being a breaking change.