### PR TITLE
Add Lax + Secured cookie options

### DIFF
--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -220,6 +220,9 @@ pub struct OAuthConfigurationBuilder {
     pub secure_cookies: bool,
     /// Whether the session cookie SameSite policy is Lax (default: `false` i.e. Strict).
     pub lax_same_site: bool,
+    /// Whether the session cookie is a browser-session cookie, i.e. no
+    /// `Max-Age`/`Expires` so it is dropped on browser close (default: `false`).
+    pub session_cookie: bool,
     /// Tracks whether `with_code_challenge_method` was called explicitly so
     /// that `with_issuer` knows not to overwrite it with the discovered value.
     code_challenge_method_explicit: bool,
@@ -249,6 +252,7 @@ impl Default for OAuthConfigurationBuilder {
             base_path: None,
             secure_cookies: true,
             lax_same_site: false,
+            session_cookie: false,
             code_challenge_method_explicit: false,
             scopes_explicit: false,
         }
@@ -465,6 +469,26 @@ impl OAuthConfigurationBuilder {
     pub fn with_lax_same_site(self, lax_same_site: bool) -> Self {
         Self {
             lax_same_site,
+            ..self
+        }
+    }
+
+    /// Set whether the session cookie is a browser-session cookie.
+    ///
+    /// Defaults to `false` (a persistent cookie with `Max-Age`). Set to `true`
+    /// to omit `Max-Age`/`Expires` so the browser drops the cookie on close.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_session_cookie(true);
+    /// ```
+    pub fn with_session_cookie(self, session_cookie: bool) -> Self {
+        Self {
+            session_cookie,
             ..self
         }
     }
@@ -922,6 +946,7 @@ impl OAuthConfigurationBuilder {
             token_request_redirect_uri: self.token_request_redirect_uri,
             secure_cookies: self.secure_cookies,
             lax_same_site: self.lax_same_site,
+            session_cookie: self.session_cookie,
         };
         Ok(layer)
     }
@@ -1426,5 +1451,40 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.base_path, "/api/auth");
+    }
+
+    #[test]
+    fn test_session_cookie_default_false() {
+        let config = OAuthConfigurationBuilder::default()
+            .with_client_id("test")
+            .with_client_secret("test")
+            .with_redirect_uri("http://localhost/callback")
+            .with_authorization_endpoint("http://localhost/auth")
+            .with_token_endpoint("http://localhost/token")
+            .with_private_cookie_key("test_key_at_least_32_bytes_long")
+            .with_session_max_age(30)
+            .with_post_logout_redirect_uri("/")
+            .build()
+            .unwrap();
+
+        assert!(!config.session_cookie);
+    }
+
+    #[test]
+    fn test_with_session_cookie_true() {
+        let config = OAuthConfigurationBuilder::default()
+            .with_client_id("test")
+            .with_client_secret("test")
+            .with_redirect_uri("http://localhost/callback")
+            .with_authorization_endpoint("http://localhost/auth")
+            .with_token_endpoint("http://localhost/token")
+            .with_private_cookie_key("test_key_at_least_32_bytes_long")
+            .with_session_max_age(30)
+            .with_post_logout_redirect_uri("/")
+            .with_session_cookie(true)
+            .build()
+            .unwrap();
+
+        assert!(config.session_cookie);
     }
 }

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -211,11 +211,15 @@ pub struct OAuthConfigurationBuilder {
     /// Optional path to custom CA certificate
     pub custom_ca_cert: Option<String>,
     /// Maximum session age in minutes
-    pub session_max_age: Option<i64>,
+    pub session_max_age_minutes: Option<i64>,
     /// Maximum token age in minutes
-    pub token_max_age: Option<i64>,
+    pub token_max_age_seconds: Option<i64>,
     /// Base path for authentication routes
     pub base_path: Option<String>,
+    /// Whether the session cookie carries the `Secure` attribute (default: `true`).
+    pub secure_cookies: bool,
+    /// Whether the session cookie SameSite policy is Lax (default: `false` i.e. Strict).
+    pub lax_same_site: bool,
     /// Tracks whether `with_code_challenge_method` was called explicitly so
     /// that `with_issuer` knows not to overwrite it with the discovered value.
     code_challenge_method_explicit: bool,
@@ -240,9 +244,11 @@ impl Default for OAuthConfigurationBuilder {
             scopes: Scopes::default(),
             code_challenge_method: CodeChallengeMethod::default(),
             custom_ca_cert: None,
-            session_max_age: None,
-            token_max_age: None,
+            session_max_age_minutes: None,
+            token_max_age_seconds: None,
             base_path: None,
+            secure_cookies: true,
+            lax_same_site: false,
             code_challenge_method_explicit: false,
             scopes_explicit: false,
         }
@@ -421,6 +427,48 @@ impl OAuthConfigurationBuilder {
             ..self
         }
     }
+
+    /// Set whether the session cookie carries the `Secure` attribute.
+    ///
+    /// Defaults to `true` (HTTPS-only). Set to `false` only for local
+    /// development served over plain `http://localhost`, where browsers can
+    /// drop a `Secure` cookie in cross-site redirect contexts (e.g. returning
+    /// from an HTTPS identity provider), breaking the session round-trip.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_secure_cookies(false); // local http dev only
+    /// ```
+    pub fn with_secure_cookies(self, secure_cookies: bool) -> Self {
+        Self {
+            secure_cookies,
+            ..self
+        }
+    }
+
+    /// Set whether the same-site policy is Lax or Strict. Useful for multi-host OIDC providers.
+    ///
+    /// Defaults to Strict (`false`). Set to `true` to use Lax SameSite policy.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_lax_same_site(true);
+    /// ```
+    pub fn with_lax_same_site(self, lax_same_site: bool) -> Self {
+        Self {
+            lax_same_site,
+            ..self
+        }
+    }
+
     /// Set the OAuth2 client ID.
     ///
     /// # Arguments
@@ -723,7 +771,7 @@ impl OAuthConfigurationBuilder {
     /// ```
     pub fn with_session_max_age(self, minutes: i64) -> Self {
         Self {
-            session_max_age: Some(minutes),
+            session_max_age_minutes: Some(minutes),
             ..self
         }
     }
@@ -747,7 +795,7 @@ impl OAuthConfigurationBuilder {
     /// ```
     pub fn with_token_max_age(self, seconds: i64) -> Self {
         Self {
-            token_max_age: Some(seconds),
+            token_max_age_seconds: Some(seconds),
             ..self
         }
     }
@@ -853,10 +901,10 @@ impl OAuthConfigurationBuilder {
             redirect_uri: self
                 .redirect_uri
                 .ok_or(Error::MissingPatameter("redirect_uri".to_string()))?,
-            session_max_age: self
-                .session_max_age
+            session_max_age_minutes: self
+                .session_max_age_minutes
                 .ok_or(Error::MissingPatameter("session_max_age".to_string()))?,
-            token_max_age: self.token_max_age,
+            token_max_age_seconds: self.token_max_age_seconds,
             authorization_endpoint: self.authorization_endpoint.ok_or(Error::MissingPatameter(
                 "authorization_endpoint".to_string(),
             ))?,
@@ -872,6 +920,8 @@ impl OAuthConfigurationBuilder {
             custom_ca_cert: self.custom_ca_cert,
             base_path: self.base_path.unwrap_or_else(|| "/auth".to_string()),
             token_request_redirect_uri: self.token_request_redirect_uri,
+            secure_cookies: self.secure_cookies,
+            lax_same_site: self.lax_same_site,
         };
         Ok(layer)
     }

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -224,7 +224,7 @@ pub struct OAuthConfigurationBuilder {
     /// `Max-Age`/`Expires` so it is dropped on browser close (default: `false`).
     pub session_cookie: bool,
     /// Whether to send `prompt=consent` on the authorization request, forcing a
-    /// re-prompt instead of silent SSO reuse (default: `false`).
+    /// re-prompt instead of silent SSO reuse (default: `true`).
     pub prompt_consent: bool,
     /// Tracks whether `with_code_challenge_method` was called explicitly so
     /// that `with_issuer` knows not to overwrite it with the discovered value.
@@ -256,7 +256,7 @@ impl Default for OAuthConfigurationBuilder {
             secure_cookies: true,
             lax_same_site: false,
             session_cookie: false,
-            prompt_consent: false,
+            prompt_consent: true,
             code_challenge_method_explicit: false,
             scopes_explicit: false,
         }
@@ -499,9 +499,9 @@ impl OAuthConfigurationBuilder {
 
     /// Set whether `prompt=consent` is sent on the authorization request.
     ///
-    /// Defaults to `false` (omitted), allowing silent SSO reuse of an existing
-    /// provider session. Set to `true` to force a consent re-prompt on every
-    /// authorization request.
+    /// Defaults to `true` (a consent re-prompt on every authorization request).
+    /// Set to `false` to omit it, allowing silent SSO reuse of an existing
+    /// provider session.
     ///
     /// # Example
     ///
@@ -509,7 +509,7 @@ impl OAuthConfigurationBuilder {
     /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
     ///
     /// let builder = OAuthConfigurationBuilder::default()
-    ///     .with_prompt_consent(true);
+    ///     .with_prompt_consent(false);
     /// ```
     pub fn with_prompt_consent(self, prompt_consent: bool) -> Self {
         Self {
@@ -1515,7 +1515,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_consent_default_false() {
+    fn test_prompt_consent_default_true() {
         let config = OAuthConfigurationBuilder::default()
             .with_client_id("test")
             .with_client_secret("test")
@@ -1525,27 +1525,27 @@ mod tests {
             .with_private_cookie_key("test_key_at_least_32_bytes_long")
             .with_session_max_age(30)
             .with_post_logout_redirect_uri("/")
-            .build()
-            .unwrap();
-
-        assert!(!config.prompt_consent);
-    }
-
-    #[test]
-    fn test_with_prompt_consent_true() {
-        let config = OAuthConfigurationBuilder::default()
-            .with_client_id("test")
-            .with_client_secret("test")
-            .with_redirect_uri("http://localhost/callback")
-            .with_authorization_endpoint("http://localhost/auth")
-            .with_token_endpoint("http://localhost/token")
-            .with_private_cookie_key("test_key_at_least_32_bytes_long")
-            .with_session_max_age(30)
-            .with_post_logout_redirect_uri("/")
-            .with_prompt_consent(true)
             .build()
             .unwrap();
 
         assert!(config.prompt_consent);
+    }
+
+    #[test]
+    fn test_with_prompt_consent_false() {
+        let config = OAuthConfigurationBuilder::default()
+            .with_client_id("test")
+            .with_client_secret("test")
+            .with_redirect_uri("http://localhost/callback")
+            .with_authorization_endpoint("http://localhost/auth")
+            .with_token_endpoint("http://localhost/token")
+            .with_private_cookie_key("test_key_at_least_32_bytes_long")
+            .with_session_max_age(30)
+            .with_post_logout_redirect_uri("/")
+            .with_prompt_consent(false)
+            .build()
+            .unwrap();
+
+        assert!(!config.prompt_consent);
     }
 }

--- a/src/authentication/builder.rs
+++ b/src/authentication/builder.rs
@@ -223,6 +223,9 @@ pub struct OAuthConfigurationBuilder {
     /// Whether the session cookie is a browser-session cookie, i.e. no
     /// `Max-Age`/`Expires` so it is dropped on browser close (default: `false`).
     pub session_cookie: bool,
+    /// Whether to send `prompt=consent` on the authorization request, forcing a
+    /// re-prompt instead of silent SSO reuse (default: `false`).
+    pub prompt_consent: bool,
     /// Tracks whether `with_code_challenge_method` was called explicitly so
     /// that `with_issuer` knows not to overwrite it with the discovered value.
     code_challenge_method_explicit: bool,
@@ -253,6 +256,7 @@ impl Default for OAuthConfigurationBuilder {
             secure_cookies: true,
             lax_same_site: false,
             session_cookie: false,
+            prompt_consent: false,
             code_challenge_method_explicit: false,
             scopes_explicit: false,
         }
@@ -489,6 +493,27 @@ impl OAuthConfigurationBuilder {
     pub fn with_session_cookie(self, session_cookie: bool) -> Self {
         Self {
             session_cookie,
+            ..self
+        }
+    }
+
+    /// Set whether `prompt=consent` is sent on the authorization request.
+    ///
+    /// Defaults to `false` (omitted), allowing silent SSO reuse of an existing
+    /// provider session. Set to `true` to force a consent re-prompt on every
+    /// authorization request.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use axum_oidc_client::auth_builder::OAuthConfigurationBuilder;
+    ///
+    /// let builder = OAuthConfigurationBuilder::default()
+    ///     .with_prompt_consent(true);
+    /// ```
+    pub fn with_prompt_consent(self, prompt_consent: bool) -> Self {
+        Self {
+            prompt_consent,
             ..self
         }
     }
@@ -947,6 +972,7 @@ impl OAuthConfigurationBuilder {
             secure_cookies: self.secure_cookies,
             lax_same_site: self.lax_same_site,
             session_cookie: self.session_cookie,
+            prompt_consent: self.prompt_consent,
         };
         Ok(layer)
     }
@@ -1486,5 +1512,40 @@ mod tests {
             .unwrap();
 
         assert!(config.session_cookie);
+    }
+
+    #[test]
+    fn test_prompt_consent_default_false() {
+        let config = OAuthConfigurationBuilder::default()
+            .with_client_id("test")
+            .with_client_secret("test")
+            .with_redirect_uri("http://localhost/callback")
+            .with_authorization_endpoint("http://localhost/auth")
+            .with_token_endpoint("http://localhost/token")
+            .with_private_cookie_key("test_key_at_least_32_bytes_long")
+            .with_session_max_age(30)
+            .with_post_logout_redirect_uri("/")
+            .build()
+            .unwrap();
+
+        assert!(!config.prompt_consent);
+    }
+
+    #[test]
+    fn test_with_prompt_consent_true() {
+        let config = OAuthConfigurationBuilder::default()
+            .with_client_id("test")
+            .with_client_secret("test")
+            .with_redirect_uri("http://localhost/callback")
+            .with_authorization_endpoint("http://localhost/auth")
+            .with_token_endpoint("http://localhost/token")
+            .with_private_cookie_key("test_key_at_least_32_bytes_long")
+            .with_session_max_age(30)
+            .with_post_logout_redirect_uri("/")
+            .with_prompt_consent(true)
+            .build()
+            .unwrap();
+
+        assert!(config.prompt_consent);
     }
 }

--- a/src/authentication/cookies.rs
+++ b/src/authentication/cookies.rs
@@ -1,0 +1,84 @@
+//! Shared helper for constructing session cookies with consistent attributes.
+//!
+//! The session cookie is created (and refreshed) after a successful token
+//! exchange and on subsequent requests, and removed on logout. All of these
+//! call sites need the same `path`, `HttpOnly`, `SameSite`, and `Secure`
+//! attributes, so the construction logic lives here to avoid drift between
+//! them (e.g. if a `domain` attribute or a different `SameSite` policy is
+//! introduced later, it only needs to change in one place).
+
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use time::Duration;
+
+/// Builds a session cookie with the standard authentication attributes:
+/// `path=/`, `HttpOnly`, `SameSite` (Lax or Strict), and `Secure`.
+///
+/// - `value: Some(v)` builds a name+value cookie suitable for `jar.add(...)`.
+/// - `value: None` builds a name-only cookie suitable for `jar.remove(...)`,
+///   which only needs to match the original cookie's attributes to be
+///   deleted by the browser.
+/// - `max_age: Some(duration)` sets the cookie to expire after `duration`;
+///   `None` omits `max_age` entirely (used for removal, where an expiry is
+///   meaningless). Callers are responsible for constructing the `Duration`
+///   with the appropriate unit (e.g. `Duration::minutes(...)`).
+pub(crate) fn build_session_cookie(
+    name: &'static str,
+    value: Option<String>,
+    lax_same_site: bool,
+    secure_cookies: bool,
+    max_age: Option<Duration>,
+) -> Cookie<'static> {
+    let mut builder = match value {
+        Some(v) => Cookie::build((name, v)),
+        None => Cookie::build(name),
+    }
+    .path("/")
+    .http_only(true)
+    .same_site(if lax_same_site {
+        SameSite::Lax
+    } else {
+        SameSite::Strict
+    })
+    .secure(secure_cookies);
+
+    if let Some(duration) = max_age {
+        builder = builder.max_age(duration);
+    }
+
+    builder.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_cookie_has_value_and_max_age() {
+        let cookie = build_session_cookie(
+            "AUTH_SESSION",
+            Some("abc123".to_string()),
+            false,
+            true,
+            Some(Duration::minutes(30)),
+        );
+
+        assert_eq!(cookie.name(), "AUTH_SESSION");
+        assert_eq!(cookie.value(), "abc123");
+        assert_eq!(cookie.path(), Some("/"));
+        assert_eq!(cookie.http_only(), Some(true));
+        assert_eq!(cookie.same_site(), Some(SameSite::Strict));
+        assert_eq!(cookie.secure(), Some(true));
+        assert_eq!(cookie.max_age(), Some(Duration::minutes(30)));
+    }
+
+    #[test]
+    fn remove_cookie_has_no_value_or_max_age() {
+        let cookie = build_session_cookie("AUTH_SESSION", None, true, false, None);
+
+        assert_eq!(cookie.name(), "AUTH_SESSION");
+        assert_eq!(cookie.value(), "");
+        assert_eq!(cookie.same_site(), Some(SameSite::Lax));
+        assert_eq!(cookie.secure(), Some(false));
+        assert_eq!(cookie.max_age(), None);
+    }
+}

--- a/src/authentication/logout/handle_default_logout.rs
+++ b/src/authentication/logout/handle_default_logout.rs
@@ -1,9 +1,12 @@
 use crate::{
-    authentication::{LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache},
+    authentication::{
+        LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache,
+        cookies::build_session_cookie,
+    },
     errors::Error,
 };
 use axum::response::{Html, IntoResponse, Response};
-use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
+use axum_extra::extract::PrivateCookieJar;
 use futures_util::future::BoxFuture;
 use http::request::Parts;
 use std::sync::Arc;
@@ -34,13 +37,13 @@ impl LogoutHandler for DefaultLogoutHandler {
             }
 
             // Remove the session cookie
-            let jar = jar.remove(
-                Cookie::build(SESSION_KEY)
-                    .path("/")
-                    .http_only(true)
-                    .same_site(axum_extra::extract::cookie::SameSite::Strict)
-                    .secure(true),
-            );
+            let jar = jar.remove(build_session_cookie(
+                SESSION_KEY,
+                None,
+                configuration.lax_same_site,
+                configuration.secure_cookies,
+                None,
+            ));
 
             Ok((
                 jar,

--- a/src/authentication/logout/handle_oidc_logout.rs
+++ b/src/authentication/logout/handle_oidc_logout.rs
@@ -1,12 +1,15 @@
 use axum::response::{Html, IntoResponse, Redirect, Response};
-use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
+use axum_extra::extract::PrivateCookieJar;
 use futures_util::future::BoxFuture;
 use http::request::Parts;
 use std::sync::Arc;
 use urlencoding::encode;
 
 use crate::{
-    authentication::{LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache},
+    authentication::{
+        LogoutHandler, OAuthConfiguration, SESSION_KEY, cache::AuthCache,
+        cookies::build_session_cookie,
+    },
     errors::Error,
 };
 
@@ -56,13 +59,13 @@ impl LogoutHandler for OidcLogoutHandler {
             }
 
             // Remove the session cookie
-            let jar = jar.remove(
-                Cookie::build(SESSION_KEY)
-                    .path("/")
-                    .http_only(true)
-                    .same_site(axum_extra::extract::cookie::SameSite::Strict)
-                    .secure(true),
-            );
+            let jar = jar.remove(build_session_cookie(
+                SESSION_KEY,
+                None,
+                configuration.lax_same_site,
+                configuration.secure_cookies,
+                None,
+            ));
 
             // If OIDC end session endpoint is configured, redirect there with id_token_hint
             if let Some(id_token_value) = id_token {

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -318,10 +318,9 @@ pub struct OAuthConfiguration {
     pub session_cookie: bool,
     /// Whether to send `prompt=consent` on the authorization request.
     ///
-    /// `false` (default) omits it, allowing silent SSO reuse of an existing
-    /// provider session. Set to `true` to force the provider to re-prompt for
-    /// consent on every authorization request (e.g. to guarantee a fresh
-    /// refresh token).
+    /// `true` (default) forces the provider to re-prompt for consent on every
+    /// authorization request. Set to `false` to omit it, allowing silent SSO
+    /// reuse of an existing provider session.
     pub prompt_consent: bool,
 }
 

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -316,6 +316,13 @@ pub struct OAuthConfiguration {
     /// browser restarts. Set to `true` to omit `Max-Age`/`Expires` entirely,
     /// making it a session cookie that the browser drops when it closes.
     pub session_cookie: bool,
+    /// Whether to send `prompt=consent` on the authorization request.
+    ///
+    /// `false` (default) omits it, allowing silent SSO reuse of an existing
+    /// provider session. Set to `true` to force the provider to re-prompt for
+    /// consent on every authorization request (e.g. to guarantee a fresh
+    /// refresh token).
+    pub prompt_consent: bool,
 }
 
 /// Session cookie key name.

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -310,6 +310,12 @@ pub struct OAuthConfiguration {
     ///
     /// `false` (default) uses Strict SameSite policy. Set to `true` to use Lax.
     pub lax_same_site: bool,
+    /// Whether the session cookie is a browser-session cookie.
+    ///
+    /// `false` (default) sets `Max-Age` on the cookie so it persists across
+    /// browser restarts. Set to `true` to omit `Max-Age`/`Expires` entirely,
+    /// making it a session cookie that the browser drops when it closes.
+    pub session_cookie: bool,
 }
 
 /// Session cookie key name.

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -73,6 +73,7 @@ use std::{
 };
 pub mod builder;
 pub mod cache;
+pub mod cookies;
 pub mod logout;
 #[cfg(feature = "moka-cache")]
 pub mod moka;
@@ -199,7 +200,7 @@ impl AuthSession {
             token_type: response.token_type.to_owned(),
             refresh_token: response.refresh_token.clone(),
             scope: response.scope.clone(),
-            expires: calculate_token_expiration(response.expires_in, conf.token_max_age),
+            expires: calculate_token_expiration(response.expires_in, conf.token_max_age_seconds),
         }
     }
 }
@@ -231,7 +232,7 @@ impl From<CodeChallengeMethod> for Method {
 /// * `scopes` - Space-separated list of OAuth2 scopes
 /// * `code_challenge_method` - PKCE code challenge method
 /// * `custom_ca_cert` - Optional path to custom CA certificate
-/// * `session_max_age` - Maximum session age in seconds
+/// * `session_max_age` - Maximum session age in minutes
 /// * `token_max_age` - Optional maximum token age in seconds
 ///
 /// # Examples
@@ -294,11 +295,21 @@ pub struct OAuthConfiguration {
     /// Optional path to custom CA certificate file
     pub custom_ca_cert: Option<String>,
     /// Maximum session age in seconds
-    pub session_max_age: i64,
+    pub session_max_age_minutes: i64,
     /// Optional maximum token age in seconds
-    pub token_max_age: Option<i64>,
+    pub token_max_age_seconds: Option<i64>,
     /// Base path for authentication routes (default: "/auth")
     pub base_path: String,
+    /// Whether the session cookie carries the `Secure` attribute.
+    ///
+    /// `true` (default) restricts the cookie to HTTPS. Set to `false` only for
+    /// local development over plain `http://localhost`, where a `Secure` cookie
+    /// can be dropped by the browser in cross-site redirect contexts.
+    pub secure_cookies: bool,
+    /// Whether the session cookie SameSite policy is Lax.
+    ///
+    /// `false` (default) uses Strict SameSite policy. Set to `true` to use Lax.
+    pub lax_same_site: bool,
 }
 
 /// Session cookie key name.
@@ -507,6 +518,21 @@ where
             .get(SESSION_KEY)
             .map(|cookie| cookie.value().to_string());
 
+        // Per-request cookie-state visibility for auth debugging (debug level).
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let raw_has_cookie = headers
+                .get(http::header::COOKIE)
+                .and_then(|v| v.to_str().ok())
+                .map(|c| c.contains(SESSION_KEY))
+                .unwrap_or(false);
+            tracing::debug!(
+                path = %path,
+                raw_cookie_header_has_session = raw_has_cookie,
+                has_decrypted_session = session_id.is_some(),
+                "auth: request received"
+            );
+        }
+
         let base_path = &configuration.base_path;
         let auth_route = base_path.clone();
         let callback_route = format!("{}/callback", base_path);
@@ -524,8 +550,15 @@ where
                     })
                     .and_then(|map| map.get("redirect").cloned());
 
+                let existing_session_id = session_id.clone();
                 Box::pin(async move {
-                    Ok(dispatch_auth(configuration, cache, post_login_redirect).await)
+                    Ok(dispatch_auth(
+                        configuration,
+                        cache,
+                        post_login_redirect,
+                        existing_session_id,
+                    )
+                    .await)
                 })
             }
             p if p == callback_route => {
@@ -560,7 +593,31 @@ async fn dispatch_auth(
     configuration: Arc<OAuthConfiguration>,
     cache: Arc<dyn AuthCache + Send + Sync>,
     post_login_redirect: Option<String>,
+    existing_session_id: Option<String>,
 ) -> Response {
+    // If the request already carries a valid, live session, do not start a new
+    // OIDC round-trip. Restarting the flow for an already-authenticated user
+    // creates a redirect loop: /auth → provider → /auth/callback (sets a new
+    // cookie, redirects to /) → the app or browser hits /auth again → repeat.
+    // Instead, send the user straight to their intended destination.
+    if let Some(session_id) = existing_session_id
+        && matches!(cache.get_auth_session(&session_id).await, Ok(Some(_)))
+    {
+        let target = match post_login_redirect {
+            Some(path) if path.starts_with('/') && !path.starts_with("//") => path,
+            _ => "/".to_string(),
+        };
+        tracing::debug!(
+            %target,
+            "auth: request to auth route already has a valid session; \
+             skipping OIDC flow and redirecting to app"
+        );
+        // 303 See Other: the correct redirect after a state-changing auth step.
+        // Unlike 307, it is not re-driven by the browser and avoids the rapid
+        // "redirected too many times" bounce when /auth is the active navigation.
+        return axum::response::Redirect::to(&target).into_response();
+    }
+
     handle_auth(configuration, cache, post_login_redirect)
         .await
         .unwrap_or_else(IntoResponse::into_response)

--- a/src/authentication/router/handle_auth.rs
+++ b/src/authentication/router/handle_auth.rs
@@ -20,6 +20,7 @@ fn create_auth_request(
         scopes,
         code_challenge_method,
         audience,
+        prompt_consent,
         ..
     } = configuration;
 
@@ -30,12 +31,17 @@ fn create_auth_request(
         ("client_id", client_id.as_str()),
         ("redirect_uri", redirect_uri.as_str()),
         ("access_type", "offline"),
-        ("prompt", "consent"),
         ("state", state),
         ("scope", scopes.as_str()),
         ("code_challenge", code_challenge.as_str()),
         ("code_challenge_method", code_challenge_method.as_str()),
     ];
+
+    // Only force a consent re-prompt when explicitly configured; otherwise omit
+    // `prompt` so the provider can silently reuse an existing SSO session.
+    if *prompt_consent {
+        params.push(("prompt", "consent"));
+    }
 
     if let Some(audience) = audience {
         params.push(("audience", audience.as_str()));
@@ -98,5 +104,38 @@ mod tests {
             .find_map(|(key, value)| (key == "audience").then_some(value.into_owned()));
 
         assert_eq!(audience.as_deref(), Some("https://api.example.com"));
+    }
+
+    fn prompt_param(url: &str) -> Option<String> {
+        let url = reqwest::Url::parse(url).expect("auth URL should parse");
+        url.query_pairs()
+            .find_map(|(key, value)| (key == "prompt").then_some(value.into_owned()))
+    }
+
+    #[test]
+    fn create_auth_request_omits_prompt_by_default() {
+        let configuration = create_test_config();
+        let method: Method = configuration.code_challenge_method.to_owned().into();
+        let (_, code_challenge) = Code::generate_using(method, Length::MAX).into_pair();
+
+        let url = create_auth_request(&configuration, &code_challenge, "test-state")
+            .expect("auth URL should be valid");
+
+        assert_eq!(prompt_param(&url), None);
+        assert!(url.contains("access_type=offline"));
+    }
+
+    #[test]
+    fn create_auth_request_includes_prompt_when_enabled() {
+        let mut configuration = create_test_config();
+        configuration.prompt_consent = true;
+        let method: Method = configuration.code_challenge_method.to_owned().into();
+        let (_, code_challenge) = Code::generate_using(method, Length::MAX).into_pair();
+
+        let url = create_auth_request(&configuration, &code_challenge, "test-state")
+            .expect("auth URL should be valid");
+
+        assert_eq!(prompt_param(&url).as_deref(), Some("consent"));
+        assert!(url.contains("access_type=offline"));
     }
 }

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -1,4 +1,4 @@
-use axum::response::{Html, IntoResponse, Response};
+use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::PrivateCookieJar;
 
 use http::{StatusCode, Uri, request::Parts};
@@ -178,17 +178,14 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
     // provider echoes the state back verbatim, but a defensive check here
     // prevents any open-redirect if the state were somehow tampered with.
     let redirect_to = match post_login_redirect {
-        Some(path) if path.starts_with('/') && !path.starts_with("//") => {
-            html_escape::encode_safe(&path).to_string()
-        }
+        Some(path) if path.starts_with('/') && !path.starts_with("//") => path,
         _ => "/".to_string(),
     };
 
-    Ok((
-        jar,
-        Html(format!(
-            r#"<head><meta http-equiv="Refresh" content="0; URL={redirect_to}" /></head>"#
-        )),
-    )
-        .into_response())
+    // Use a real HTTP 303 redirect rather than an HTML meta-refresh: the browser
+    // commits the `Set-Cookie` header on this response before following the
+    // `Location`, so the subsequent request carries the session cookie. A
+    // meta-refresh can navigate before the cookie is committed, producing a
+    // "no cookie" bounce back through /auth (the redirect loop).
+    Ok((jar, Redirect::to(&redirect_to)).into_response())
 }

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -1,5 +1,5 @@
 use axum::response::{Html, IntoResponse, Response};
-use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
+use axum_extra::extract::PrivateCookieJar;
 
 use http::{StatusCode, Uri, request::Parts};
 use reqwest::{self, Client};
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::{
     authentication::{
         cache::AuthCache,
+        cookies::build_session_cookie,
         session::AuthSession,
         {OAuthConfiguration, SESSION_KEY},
     },
@@ -156,14 +157,15 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
         .set_auth_session(&id, AuthSession::new(&token_response, &configuration))
         .await?;
 
-    let jar = jar.add(
-        Cookie::build((SESSION_KEY, id.clone()))
-            .path("/")
-            .http_only(true)
-            .same_site(axum_extra::extract::cookie::SameSite::Strict)
-            .secure(true)
-            .max_age(Duration::minutes(60)),
-    );
+    tracing::debug!("auth: token exchange succeeded, session stored and cookie set");
+
+    let jar = jar.add(build_session_cookie(
+        SESSION_KEY,
+        Some(id.clone()),
+        configuration.lax_same_site,
+        configuration.secure_cookies,
+        Some(Duration::minutes(configuration.session_max_age_minutes)),
+    ));
 
     // Belt-and-suspenders validation: re-check the redirect path even though
     // handle_auth already validated it before embedding it in the state.  The

--- a/src/authentication/router/handle_callback.rs
+++ b/src/authentication/router/handle_callback.rs
@@ -159,12 +159,18 @@ pub async fn handle_callback(parts: &mut Parts, uri: Uri) -> Result<Response, Er
 
     tracing::debug!("auth: token exchange succeeded, session stored and cookie set");
 
+    let max_age = if configuration.session_cookie {
+        // Browser-session cookie: omit Max-Age so the browser drops it on close.
+        None
+    } else {
+        Some(Duration::minutes(configuration.session_max_age_minutes))
+    };
     let jar = jar.add(build_session_cookie(
         SESSION_KEY,
         Some(id.clone()),
         configuration.lax_same_site,
         configuration.secure_cookies,
-        Some(Duration::minutes(configuration.session_max_age_minutes)),
+        max_age,
     ));
 
     // Belt-and-suspenders validation: re-check the redirect path even though

--- a/src/authentication/router/handle_default.rs
+++ b/src/authentication/router/handle_default.rs
@@ -34,12 +34,20 @@ where
                 {
                     return Ok(err.into_response());
                 }
+                // Renewal still extends the server-side session (above); the
+                // cookie itself omits Max-Age in session-cookie mode so it stays
+                // a browser-session cookie across renewals too.
+                let cookie_max_age = if configuration.session_cookie {
+                    None
+                } else {
+                    Some(session_max_age)
+                };
                 jar.add(build_session_cookie(
                     SESSION_KEY,
                     Some(id),
                     configuration.lax_same_site,
                     configuration.secure_cookies,
-                    Some(session_max_age),
+                    cookie_max_age,
                 ))
             }
             None => jar,

--- a/src/authentication/router/handle_default.rs
+++ b/src/authentication/router/handle_default.rs
@@ -1,12 +1,11 @@
 use axum::response::{IntoResponse, Response};
-use axum_extra::extract::{
-    PrivateCookieJar,
-    cookie::{Cookie, Key},
-};
+use axum_extra::extract::{PrivateCookieJar, cookie::Key};
 use futures_util::future::BoxFuture;
 use time::Duration;
 
-use crate::authentication::{OAuthConfiguration, SESSION_KEY, cache::AuthCache};
+use crate::authentication::{
+    OAuthConfiguration, SESSION_KEY, cache::AuthCache, cookies::build_session_cookie,
+};
 
 use std::sync::Arc;
 
@@ -18,26 +17,30 @@ pub fn handle_default<F, E>(
     future: F,
 ) -> BoxFuture<'static, Result<Response, E>>
 where
-    F: std::future::Future<Output = Result<Response, E>> + Send + 'static,
+    F: Future<Output = Result<Response, E>> + Send + 'static,
 {
-    let session_max_age = configuration.session_max_age;
-
     Box::pin(async move {
         let response = future.await?;
-
+        let session_max_age = Duration::minutes(configuration.session_max_age_minutes);
         let jar = match session_id {
             Some(id) => {
-                if let Err(err) = cache.extend_auth_session(&id, session_max_age).await {
+                // `AuthCache::extend_auth_session` takes its `ttl` in seconds
+                // (it maps directly onto Redis `EXPIRE`, SQL `expires_at`,
+                // and moka TTLs), while `session_max_age` is configured in
+                // minutes — convert explicitly at this boundary.
+                if let Err(err) = cache
+                    .extend_auth_session(&id, session_max_age.whole_seconds())
+                    .await
+                {
                     return Ok(err.into_response());
                 }
-                jar.add(
-                    Cookie::build((SESSION_KEY, id))
-                        .path("/")
-                        .http_only(true)
-                        .secure(true)
-                        .same_site(axum_extra::extract::cookie::SameSite::Strict)
-                        .max_age(Duration::minutes(session_max_age)),
-                )
+                jar.add(build_session_cookie(
+                    SESSION_KEY,
+                    Some(id),
+                    configuration.lax_same_site,
+                    configuration.secure_cookies,
+                    Some(session_max_age),
+                ))
             }
             None => jar,
         };

--- a/src/authentication/router/test_helpers.rs
+++ b/src/authentication/router/test_helpers.rs
@@ -85,9 +85,11 @@ pub(crate) fn create_test_config() -> OAuthConfiguration {
         post_logout_redirect_uri: "/".to_string(),
         scopes: "openid email".to_string(),
         code_challenge_method: CodeChallengeMethod::S256,
-        session_max_age: 30,
-        token_max_age: Some(60),
+        session_max_age_minutes: 30,
+        token_max_age_seconds: Some(60),
         custom_ca_cert: None,
         base_path: "/auth".to_string(),
+        secure_cookies: true,
+        lax_same_site: false,
     }
 }

--- a/src/authentication/router/test_helpers.rs
+++ b/src/authentication/router/test_helpers.rs
@@ -92,5 +92,6 @@ pub(crate) fn create_test_config() -> OAuthConfiguration {
         secure_cookies: true,
         lax_same_site: false,
         session_cookie: false,
+        prompt_consent: false,
     }
 }

--- a/src/authentication/router/test_helpers.rs
+++ b/src/authentication/router/test_helpers.rs
@@ -91,5 +91,6 @@ pub(crate) fn create_test_config() -> OAuthConfiguration {
         base_path: "/auth".to_string(),
         secure_cookies: true,
         lax_same_site: false,
+        session_cookie: false,
     }
 }

--- a/src/extractors/shared.rs
+++ b/src/extractors/shared.rs
@@ -121,7 +121,7 @@ pub async fn extract_and_refresh_session(
                 // Calculate new expiration time — if both are absent, leave the
                 // existing value untouched so the session keeps whatever expiry it had
                 if let Some(new_expires) =
-                    calculate_token_expiration(refresh_response.expires_in, config.token_max_age)
+                    calculate_token_expiration(refresh_response.expires_in, config.token_max_age_seconds)
                 {
                     session.expires = Some(new_expires);
                 }


### PR DESCRIPTION
Add support for:
- Unsecure cookies (firefox development/localhost).
- SameSite::Lax from cross site authentication.

## Summary by Sourcery

Add configurable session cookie security settings and improve handling of authenticated requests to the auth route.

New Features:
- Introduce configuration flags to control the session cookie Secure attribute and to switch between Strict and Lax SameSite policies.
- Expose builder methods to set cookie security options for different deployment and development environments.

Bug Fixes:
- Avoid redirect loops by detecting existing valid sessions on the auth route and redirecting users directly to their target instead of restarting the OIDC flow.

Enhancements:
- Add debug-level tracing around incoming auth requests, cookie presence, and successful token exchanges for easier authentication debugging.

Tests:
- Extend authentication test configuration to cover the new cookie security settings.